### PR TITLE
Make RandomMaterial use weights for better modularity

### DIFF
--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -13,7 +13,7 @@ extends GaeaMaterial
 
 
 ##Represent the weight of each material.[br]
-##For example, if you want to change the probability of spawning the first material, you need to modify the value of the first element in the weight array.[br]
+##For example, if you want to change the probability of using the first material, you need to modify the value of the first element in the weight array.[br]
 ##Higher values increase the chances of obtaining the material.[br]
 ##The object picked is determined by the [method RandomNumberGenerator.rand_weighted] function, [url=https://docs.godotengine.org/en/latest/tutorials/math/random_number_generation.html#weighted-random-probability]check the documentation here.[/url]
 @export var weights: PackedFloat32Array : 

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -7,7 +7,7 @@ extends GaeaMaterial
 	set(value):
 		materials = value
 		weights.resize(materials.size())
-		weights[-1] = 1.0
+		weights[-1] = 100
 		
 		notify_property_list_changed()
 
@@ -16,14 +16,29 @@ extends GaeaMaterial
 ##For example, if you want to change the probability of using the first material, you need to modify the value of the first element in the weight array.[br]
 ##Higher values increase the chances of obtaining the material.[br]
 ##The object picked is determined by the [method RandomNumberGenerator.rand_weighted] function, [url=https://docs.godotengine.org/en/latest/tutorials/math/random_number_generation.html#weighted-random-probability]check the documentation here.[/url]
-@export var weights: PackedFloat32Array : 
+@export var weights: PackedInt32Array : 
 	#Avoid editing the weights array
 	set(value):
 		if value.size() == materials.size():
 			weights = value
 
 
+func get_random_material_index() -> int:
+	var weights_sum: int = 0
+	
+	for weight in weights:
+		weights_sum += weight
+	
+	var remaining_distance: int = randf() * weights_sum
+	
+	for i in range(weights.size()):
+		remaining_distance -= weights[i]
+		if remaining_distance < 0:
+			return i
+	
+	return -1
+
+
 ##Return the random picked material. 
 func get_resource() -> GaeaMaterial:
-	var random = RandomNumberGenerator.new()
-	return materials[random.rand_weighted(weights)]
+	return materials[get_random_material_index()]

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -5,11 +5,15 @@ extends GaeaMaterial
 
 @export var materials: Array[GaeaMaterial] :
 	set(value):
-		if value.size() != materials.size():
-			weights.resize(materials.size())
-			weights[-1] = 100
-		
+		var pre_size: int = materials.size()
 		materials = value
+		
+		#Resize the weights array to match the materials array size
+		if materials.size() > pre_size:
+			weights.resize(value.size())
+			weights[-1] = 100
+		elif materials.size() < pre_size:
+			weights.resize(value.size())
 		
 		notify_property_list_changed()
 
@@ -19,7 +23,7 @@ extends GaeaMaterial
 ##Higher values increase the chances of obtaining the material.[br]
 ##The object picked is determined by the [method RandomNumberGenerator.rand_weighted] function, [url=https://docs.godotengine.org/en/latest/tutorials/math/random_number_generation.html#weighted-random-probability]check the documentation here.[/url]
 @export var weights: PackedInt32Array : 
-	#Avoid editing the weights array
+	#Avoid editing the weights array size
 	set(value):
 		if value.size() == materials.size():
 			weights = value

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -31,12 +31,10 @@ extends GaeaMaterial
 
 func get_random_material_index() -> int:
 	var weights_sum: int = 0
-	
 	for weight in weights:
 		weights_sum += weight
-	
+
 	var remaining_distance: int = randf() * weights_sum
-	
 	for i in range(weights.size()):
 		remaining_distance -= weights[i]
 		if remaining_distance < 0:
@@ -47,4 +45,8 @@ func get_random_material_index() -> int:
 
 ##Return the random picked material. 
 func get_resource() -> GaeaMaterial:
-	return materials[get_random_material_index()]
+	var material_index: int = get_random_material_index()
+	
+	if material_index != -1:
+		return materials[material_index]
+	return null

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -3,8 +3,27 @@ class_name RandomMaterial
 extends GaeaMaterial
 
 
-@export var materials: Array[GaeaMaterial]
+@export var materials: Array[GaeaMaterial] :
+	set(value):
+		materials = value
+		weights.resize(materials.size())
+		weights[-1] = 1.0
+		
+		notify_property_list_changed()
 
 
+##Represent the weight of each material.[br]
+##For example, if you want to change the probability of spawning the first material, you need to modify the value of the first element in the weight array.[br]
+##Higher values increase the chances of obtaining the material.[br]
+##The object picked is determined by the [method RandomNumberGenerator.rand_weighted] function, [url=https://docs.godotengine.org/en/latest/tutorials/math/random_number_generation.html#weighted-random-probability]check the documentation here.[/url]
+@export var weights: PackedFloat32Array : 
+	#Avoid editing the weights array
+	set(value):
+		if value.size() == materials.size():
+			weights = value
+
+
+##Return the random picked material. 
 func get_resource() -> GaeaMaterial:
-	return materials.pick_random().get_resource()
+	var random = RandomNumberGenerator.new()
+	return materials[random.rand_weighted(weights)]

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -5,9 +5,11 @@ extends GaeaMaterial
 
 @export var materials: Array[GaeaMaterial] :
 	set(value):
+		if value.size() != materials.size():
+			weights.resize(materials.size())
+			weights[-1] = 100
+		
 		materials = value
-		weights.resize(materials.size())
-		weights[-1] = 100
 		
 		notify_property_list_changed()
 


### PR DESCRIPTION
This feature gives more control over which tile should be spawned when using the ran_material resource.
The weight element is automatically created when a material is added.
The higher the value, the greater the chance of using the material.

https://github.com/user-attachments/assets/d22d67c4-73f8-41b2-b0e4-6f15beb00a56


