### PR TITLE
Improve `weights` Array Handling in `RandomMaterial`

### DIFF
--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -22,7 +22,7 @@ var _random = RandomNumberGenerator.new()
 	set(value):
 		var pre_size: int = materials.size()
 		materials = value
-		
+
 		#Resize the weights array to match the materials array size
 		if materials.size() > pre_size:
 			weights.resize(value.size())
@@ -30,9 +30,8 @@ var _random = RandomNumberGenerator.new()
 				weights[index] = 100.0
 		elif materials.size() < pre_size:
 			weights.resize(value.size())
-		
-		notify_property_list_changed()
 
+		notify_property_list_changed()
 
 ## Represent the weight of each material.[br]
 ## For example, if you want to change the probability of using the first material, you need to modify the value of the first element in the weight array.[br]
@@ -46,10 +45,10 @@ var _random = RandomNumberGenerator.new()
 			weights = value
 
 
-## Return the random picked material. 
+## Return the random picked material.
 func get_resource() -> GaeaMaterial:
 	var material_index: int = _random.rand_weighted(weights)
-	
+
 	if material_index != -1:
 		return materials[material_index]
 	return null

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -11,7 +11,8 @@ extends GaeaMaterial
 		#Resize the weights array to match the materials array size
 		if materials.size() > pre_size:
 			weights.resize(value.size())
-			weights[-1] = 100
+			for index in range(pre_size, materials.size()):
+				weights[index] = 100
 		elif materials.size() < pre_size:
 			weights.resize(value.size())
 		

--- a/addons/gaea/resources/materials/random_material.gd
+++ b/addons/gaea/resources/materials/random_material.gd
@@ -1,9 +1,24 @@
 @tool
-class_name RandomMaterial
-extends GaeaMaterial
+## A material that randomly selects between multiple materials.[br]
+## [br]
+## This class allows you to create a material that will randomly choose between a set of provided materials.[br]
+## Each material can have a different weight assigned to it, which affects its probability of being selected.[br]
+## [br]
+## Example:[br]
+## [codeblock]
+## var random_material = RandomMaterial.new()
+## random_material.materials = [grass_material, stone_material]
+## random_material.weights = [70.0, 30.0]
+## # 70% chance for grass, 30% for stone
+## [/codeblock]
+class_name RandomMaterial extends GaeaMaterial
 
+var _random = RandomNumberGenerator.new()
 
-@export var materials: Array[GaeaMaterial] :
+## An array of materials to randomly choose from.[br]
+## Each material in this array has a chance to be selected during [method get_resource] calls.[br]
+## The probability of each material being selected is determined by its corresponding value in the [member weights] array.
+@export var materials: Array[GaeaMaterial]:
 	set(value):
 		var pre_size: int = materials.size()
 		materials = value
@@ -12,41 +27,28 @@ extends GaeaMaterial
 		if materials.size() > pre_size:
 			weights.resize(value.size())
 			for index in range(pre_size, materials.size()):
-				weights[index] = 100
+				weights[index] = 100.0
 		elif materials.size() < pre_size:
 			weights.resize(value.size())
 		
 		notify_property_list_changed()
 
 
-##Represent the weight of each material.[br]
-##For example, if you want to change the probability of using the first material, you need to modify the value of the first element in the weight array.[br]
-##Higher values increase the chances of obtaining the material.[br]
-##The object picked is determined by the [method RandomNumberGenerator.rand_weighted] function, [url=https://docs.godotengine.org/en/latest/tutorials/math/random_number_generation.html#weighted-random-probability]check the documentation here.[/url]
-@export var weights: PackedInt32Array : 
+## Represent the weight of each material.[br]
+## For example, if you want to change the probability of using the first material, you need to modify the value of the first element in the weight array.[br]
+## Higher values increase the chances of obtaining the material.[br]
+## The default weight value for new materials is [code]100.0[/code].[br]
+## The object picked is determined by the [method RandomNumberGenerator.rand_weighted] function.
+@export var weights: PackedFloat32Array:
 	#Avoid editing the weights array size
 	set(value):
 		if value.size() == materials.size():
 			weights = value
 
 
-func get_random_material_index() -> int:
-	var weights_sum: int = 0
-	for weight in weights:
-		weights_sum += weight
-
-	var remaining_distance: int = randf() * weights_sum
-	for i in range(weights.size()):
-		remaining_distance -= weights[i]
-		if remaining_distance < 0:
-			return i
-	
-	return -1
-
-
-##Return the random picked material. 
+## Return the random picked material. 
 func get_resource() -> GaeaMaterial:
-	var material_index: int = get_random_material_index()
+	var material_index: int = _random.rand_weighted(weights)
 	
 	if material_index != -1:
 		return materials[material_index]

--- a/scenes/walker_demo/floor_walker.tres
+++ b/scenes/walker_demo/floor_walker.tres
@@ -58,7 +58,7 @@ metadata/_custom_type_script = "uid://e45byecr4gi6"
 [sub_resource type="Resource" id="Resource_e1h74"]
 script = ExtResource("3_kk1e5")
 materials = Array[ExtResource("2_du0iw")]([SubResource("Resource_o0o4j"), SubResource("Resource_h5ves")])
-weights = PackedInt32Array(100, 100)
+weights = PackedFloat32Array(100, 100)
 preview_color = Color(0.564382, 0.180166, 0.575045, 1)
 metadata/_custom_type_script = "uid://dtocuov1r8agi"
 
@@ -83,7 +83,7 @@ metadata/_custom_type_script = "uid://e45byecr4gi6"
 [sub_resource type="Resource" id="Resource_y3srg"]
 script = ExtResource("3_kk1e5")
 materials = Array[ExtResource("2_du0iw")]([SubResource("Resource_lm46c"), SubResource("Resource_jlmdo")])
-weights = PackedInt32Array(100, 100)
+weights = PackedFloat32Array(54.321, 100)
 preview_color = Color(0.0559988, 0.886948, 0.662938, 1)
 metadata/_custom_type_script = "uid://dtocuov1r8agi"
 
@@ -108,7 +108,7 @@ metadata/_custom_type_script = "uid://e45byecr4gi6"
 [sub_resource type="Resource" id="Resource_mfiu2"]
 script = ExtResource("3_kk1e5")
 materials = Array[ExtResource("2_du0iw")]([SubResource("Resource_qtqn2"), SubResource("Resource_wbro0")])
-weights = PackedInt32Array(100, 100)
+weights = PackedFloat32Array(50, 100)
 preview_color = Color(0.604519, 0.617006, 0.236859, 1)
 metadata/_custom_type_script = "uid://dtocuov1r8agi"
 

--- a/scenes/walker_demo/floor_walker.tres
+++ b/scenes/walker_demo/floor_walker.tres
@@ -58,6 +58,7 @@ metadata/_custom_type_script = "uid://e45byecr4gi6"
 [sub_resource type="Resource" id="Resource_e1h74"]
 script = ExtResource("3_kk1e5")
 materials = Array[ExtResource("2_du0iw")]([SubResource("Resource_o0o4j"), SubResource("Resource_h5ves")])
+weights = PackedInt32Array(100, 100)
 preview_color = Color(0.564382, 0.180166, 0.575045, 1)
 metadata/_custom_type_script = "uid://dtocuov1r8agi"
 
@@ -82,6 +83,7 @@ metadata/_custom_type_script = "uid://e45byecr4gi6"
 [sub_resource type="Resource" id="Resource_y3srg"]
 script = ExtResource("3_kk1e5")
 materials = Array[ExtResource("2_du0iw")]([SubResource("Resource_lm46c"), SubResource("Resource_jlmdo")])
+weights = PackedInt32Array(100, 100)
 preview_color = Color(0.0559988, 0.886948, 0.662938, 1)
 metadata/_custom_type_script = "uid://dtocuov1r8agi"
 
@@ -106,6 +108,7 @@ metadata/_custom_type_script = "uid://e45byecr4gi6"
 [sub_resource type="Resource" id="Resource_mfiu2"]
 script = ExtResource("3_kk1e5")
 materials = Array[ExtResource("2_du0iw")]([SubResource("Resource_qtqn2"), SubResource("Resource_wbro0")])
+weights = PackedInt32Array(100, 100)
 preview_color = Color(0.604519, 0.617006, 0.236859, 1)
 metadata/_custom_type_script = "uid://dtocuov1r8agi"
 


### PR DESCRIPTION
# 🛠️ Refactor: Improve `weights` Array Handling in `RandomMaterial`

## Summary

This PR refactors the management of the `weights` array in the `RandomMaterial` resource to ensure correct initialization and consistent resizing behavior.

### Problem

Previously, only the last element in the `weights` array was initialized with the default value of `100`. This could lead to unintentional bias or incorrect behavior when generating random materials.

### Solution

- Improved the initialization logic to ensure that all weights are properly set to a default value.
- Refactored the resizing behavior to maintain consistency across the entire array.
- Initialized `weights` values in the `floor_walker.tres` resource files for data consistency.

### Notes

> We could eventually switch to using `rand_weighted()` from Godot's `RandomNumberGenerator` for more robust random selection.  
> This would require converting the `weights` `PackedInt32Array` to a `PackedFloat32Array`:  
> 📚 [Godot Documentation – rand_weighted](https://docs.godotengine.org/en/latest/classes/class_randomnumbergenerator.html#class-randomnumbergenerator-method-rand-weighted)

---

Let me know if you prefer to switch to `rand_weighted()` now or keep the current manual handling.
