### PR TITLE
Prevent code execution during scene editing and free old bottom panel resources

### DIFF
--- a/addons/gaea/editor/create_node_tree.gd
+++ b/addons/gaea/editor/create_node_tree.gd
@@ -13,6 +13,8 @@ var _custom_nodes_path: String
 
 
 func _ready() -> void:
+	if is_part_of_edited_scene():
+		return
 	populate()
 
 

--- a/addons/gaea/editor/link_popup.gd
+++ b/addons/gaea/editor/link_popup.gd
@@ -14,6 +14,8 @@ signal new_reroute_requested(connection: Dictionary)
 
 
 func _ready() -> void:
+	if is_part_of_edited_scene():
+		return
 	hide()
 	id_pressed.connect(_on_id_pressed)
 

--- a/addons/gaea/editor/node_popup.gd
+++ b/addons/gaea/editor/node_popup.gd
@@ -10,6 +10,8 @@ signal create_node_popup_requested
 
 
 func _ready() -> void:
+	if is_part_of_edited_scene():
+		return
 	hide()
 	id_pressed.connect(_on_id_pressed)
 

--- a/addons/gaea/editor/panel.gd
+++ b/addons/gaea/editor/panel.gd
@@ -294,7 +294,7 @@ func _on_graph_edit_connection_to_empty(_from_node: StringName, _from_port: int,
 
 
 func _notification(what: int) -> void:
-	if what == NOTIFICATION_EDITOR_PRE_SAVE:
+	if what == NOTIFICATION_EDITOR_PRE_SAVE and not is_part_of_edited_scene():
 		_save_data()
 
 

--- a/addons/gaea/gaea.gd
+++ b/addons/gaea/gaea.gd
@@ -37,8 +37,9 @@ func _enter_tree() -> void:
 
 func _exit_tree() -> void:
 	_panel.unpopulate()
-	remove_control_from_bottom_panel(_container)
 	remove_inspector_plugin(_inspector_plugin)
+	remove_control_from_bottom_panel(_container)
+	_container.queue_free()
 
 
 func _on_selection_changed() -> void:


### PR DESCRIPTION
Ensure that certain code does not run when the scene is being edited and properly free resources associated with the old bottom panel.

This may be the cause of #258