### PR TITLE
Fix mouse position overlay Z index

### DIFF
--- a/addons/gaea/editor/panel.tscn
+++ b/addons/gaea/editor/panel.tscn
@@ -172,6 +172,7 @@ right_disconnects = true
 script = ExtResource("2_cdav6")
 
 [node name="Margin" type="MarginContainer" parent="Editor/VBoxContainer/GraphEdit"]
+z_index = 50
 layout_mode = 1
 anchors_preset = 12
 anchor_top = 1.0


### PR DESCRIPTION
Adjust the Z index of the mouse position overlay to ensure it displays correctly above other elements.