### PR TITLE
Don't clear data before saving

### DIFF
--- a/addons/gaea/editor/panel.gd
+++ b/addons/gaea/editor/panel.gd
@@ -212,11 +212,6 @@ func _save_data() -> void:
 	if not is_instance_valid(_selected_generator) or not is_instance_valid(_selected_generator.data):
 		return
 
-	_selected_generator.data.node_data.clear()
-	_selected_generator.data.resources.clear()
-	_selected_generator.data.connections.clear()
-	_selected_generator.data.other.clear()
-
 	var resources: Array[GaeaNodeResource]
 	var connections: Array[Dictionary] = _graph_edit.get_connection_list()
 	var node_data: Array[Dictionary]


### PR DESCRIPTION
I think it's was the issue for #258 You don't really need to clear the data first because they will be replaced at the end of the method.

Usualy the script was stoped when an errors occured here : 
https://github.com/gaea-godot/gaea/blob/de9fd460f439d97fa42763e9c5c15d1214114dcb/addons/gaea/editor/panel.gd#L247-L248C38

So the data was already deleted