### PR TITLE
Prioritize updates in the same branch, warn when updating from 1.X to 2.0

### DIFF
--- a/addons/gaea/editor/download_update_panel.gd
+++ b/addons/gaea/editor/download_update_panel.gd
@@ -10,6 +10,7 @@ const TEMP_FILE_PATH = "user://temp.zip"
 @onready var label: Label = $MarginContainer/VBoxContainer/Label
 @onready var download_button: Button = %DownloadButton
 @onready var release_notes_button: LinkButton = %ReleaseNotesButton
+@onready var migration_warning: Label = %MigrationWarning
 
 var next_version_release: Dictionary:
 	set(value):

--- a/addons/gaea/editor/download_update_panel.tscn
+++ b/addons/gaea/editor/download_update_panel.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://6pmddcctde0v"]
 
 [ext_resource type="Texture2D" uid="uid://b4nwpbrra72fj" path="res://addons/gaea/editor/logo.png" id="1_05fnf"]
-[ext_resource type="Script" uid="uid://wisjqo0n7ge" path="res://addons/gaea/editor/download_update_panel.gd" id="1_moikk"]
+[ext_resource type="Script" path="res://addons/gaea/editor/download_update_panel.gd" id="1_moikk"]
 
 [node name="DownloadUpdatePanel" type="Control"]
 layout_mode = 3

--- a/addons/gaea/editor/download_update_panel.tscn
+++ b/addons/gaea/editor/download_update_panel.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://6pmddcctde0v"]
 
 [ext_resource type="Texture2D" uid="uid://b4nwpbrra72fj" path="res://addons/gaea/editor/logo.png" id="1_05fnf"]
-[ext_resource type="Script" path="res://addons/gaea/editor/download_update_panel.gd" id="1_moikk"]
+[ext_resource type="Script" uid="uid://wisjqo0n7ge" path="res://addons/gaea/editor/download_update_panel.gd" id="1_moikk"]
 
 [node name="DownloadUpdatePanel" type="Control"]
 layout_mode = 3
@@ -21,7 +21,10 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 12
 theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
@@ -38,6 +41,15 @@ layout_mode = 2
 text = "v1.0.0 is available for download"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="CenterContainer3" type="CenterContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="MigrationWarning" type="Label" parent="MarginContainer/VBoxContainer/CenterContainer3"]
+unique_name_in_owner = true
+modulate = Color(0.952941, 0.611765, 0.0705882, 1)
+layout_mode = 2
+text = "Warning: Upgrading from 1.X to 2.X will break your projects!"
 
 [node name="CenterContainer" type="CenterContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/addons/gaea/editor/download_update_panel.tscn
+++ b/addons/gaea/editor/download_update_panel.tscn
@@ -47,6 +47,7 @@ layout_mode = 2
 
 [node name="MigrationWarning" type="Label" parent="MarginContainer/VBoxContainer/CenterContainer3"]
 unique_name_in_owner = true
+visible = false
 modulate = Color(0.952941, 0.611765, 0.0705882, 1)
 layout_mode = 2
 text = "Warning: Upgrading from 1.X to 2.X will break your projects!"

--- a/addons/gaea/editor/update_button.gd
+++ b/addons/gaea/editor/update_button.gd
@@ -4,7 +4,7 @@ extends Button
 ## at https://github.com/nathanhoad/godot_dialogue_manager
 
 
-const RELEASES_URL := "https://api.github.com/repos/BenjaTK/Gaea/releases"
+const RELEASES_URL := "https://api.github.com/repos/gaea-godot/gaea/releases"
 const LOCAL_CONFIG_PATH := "res://addons/gaea/plugin.cfg"
 
 
@@ -42,8 +42,19 @@ func _on_http_request_request_completed(result: int, response_code: int, headers
 	# GitHub releases are in order of creation, not order of version
 	var versions = (response as Array).filter(func(release):
 		var version: String = release.tag_name.substr(1)
+		if version.left(3) != "v1.":
+			return false
 		return _version_to_number(version) > _version_to_number(current_version)
 	)
+	if versions.size() == 0:
+		versions = (response as Array).filter(func(release):
+			var version: String = release.tag_name.substr(1)
+			return _version_to_number(version) > _version_to_number(current_version)
+		)
+		if versions.size() > 0:
+			download_update_panel.migration_warning.show()
+	
+	
 	if versions.size() > 0:
 		download_update_panel.next_version_release = versions[0]
 		text = "Gaea v%s available" % versions[0].tag_name.substr(1)
@@ -80,5 +91,3 @@ func _get_version() -> String:
 func _version_to_number(version: String) -> int:
 	var bits = version.split(".")
 	return bits[0].to_int() * 1000000 + bits[1].to_int() * 1000 + bits[2].to_int()
-
-

--- a/addons/gaea/editor/update_button.tscn
+++ b/addons/gaea/editor/update_button.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=3 format=3 uid="uid://2olhiqrswect"]
 
-[ext_resource type="Script" path="res://addons/gaea/editor/update_button.gd" id="1_8ury3"]
+[ext_resource type="Script" uid="uid://u05eg8vfnk5w" path="res://addons/gaea/editor/update_button.gd" id="1_8ury3"]
 [ext_resource type="PackedScene" uid="uid://6pmddcctde0v" path="res://addons/gaea/editor/download_update_panel.tscn" id="2_bw0il"]
 
 [node name="UpdateButton" type="Button"]
 visible = false
-text = "Gaea v1.0.0 available"
+text = "Gaea v2.0.0-beta2 available"
 flat = true
 script = ExtResource("1_8ury3")
 
@@ -13,12 +13,16 @@ script = ExtResource("1_8ury3")
 
 [node name="DownloadDialog" type="AcceptDialog" parent="."]
 title = "Update available!"
-size = Vector2i(400, 320)
+size = Vector2i(500, 400)
 unresizable = true
 min_size = Vector2i(300, 310)
 ok_button_text = "Close"
 
 [node name="DownloadUpdatePanel" parent="DownloadDialog" instance=ExtResource("2_bw0il")]
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
 
 [node name="UpdateFailedDialog" type="AcceptDialog" parent="."]
 size = Vector2i(381, 100)

--- a/addons/gaea/editor/update_button.tscn
+++ b/addons/gaea/editor/update_button.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=3 format=3 uid="uid://2olhiqrswect"]
 
-[ext_resource type="Script" uid="uid://u05eg8vfnk5w" path="res://addons/gaea/editor/update_button.gd" id="1_8ury3"]
+[ext_resource type="Script" path="res://addons/gaea/editor/update_button.gd" id="1_8ury3"]
 [ext_resource type="PackedScene" uid="uid://6pmddcctde0v" path="res://addons/gaea/editor/download_update_panel.tscn" id="2_bw0il"]
 
 [node name="UpdateButton" type="Button"]
 visible = false
-text = "Gaea v2.0.0-beta2 available"
+text = "Gaea v1.0.0 available"
 flat = true
 script = ExtResource("1_8ury3")
 


### PR DESCRIPTION
Added a version check to prioritize 1.X updates, and if none are available, show the 2.X update with a warning.