### PR TITLE
Await `_remove_children` to avoid nodes 'leaking' into other graphs when switching generators

### DIFF
--- a/addons/gaea/editor/panel.gd
+++ b/addons/gaea/editor/panel.gd
@@ -99,7 +99,7 @@ func _on_visibility_changed() -> void:
 
 #region Saving and Loading
 func populate(node: GaeaGenerator) -> void:
-	_remove_children()
+	await _remove_children()
 	_output_node = null
 
 	if is_instance_valid(_selected_generator) and _selected_generator.data_changed.is_connected(_on_data_changed):
@@ -132,13 +132,14 @@ func unpopulate() -> void:
 
 	_selected_generator = null
 
-	_remove_children()
+	await _remove_children()
 
 
 func _remove_children() -> void:
 	for child in _graph_edit.get_children():
 		if child is GraphElement:
 			child.queue_free()
+			await child.tree_exited
 
 
 func _save_data() -> void:

--- a/addons/gaea/gaea.gd
+++ b/addons/gaea/gaea.gd
@@ -34,7 +34,7 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
-	_panel.unpopulate()
+	await _panel.unpopulate()
 	remove_inspector_plugin(_inspector_plugin)
 	remove_control_from_bottom_panel(_container)
 	_container.queue_free()
@@ -51,7 +51,7 @@ func _on_selection_changed() -> void:
 		if is_instance_valid(_panel.get_selected_generator()):
 			_panel_button.hide()
 			_panel_button.set_pressed(false)
-			_panel.unpopulate()
+			await _panel.unpopulate()
 
 
 func _disable_plugin() -> void:


### PR DESCRIPTION
Fixes #322 