### PR TITLE
Fix return type of get_data function

### DIFF
--- a/addons/gaea/graph/graph_nodes/generic_classes/constant.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/constant.gd
@@ -33,6 +33,6 @@ func _get_overridden_output_port_idx(output_name: StringName) -> int:
 	return 0
 
 
-func _get_data(output_port: StringName, area: AABB, generator_data: GaeaData) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, generator_data: GaeaData) -> Variant:
 	_log_data(output_port, generator_data)
 	return _get_arg(&"value", area, generator_data)


### PR DESCRIPTION
Change the return type of the `_get_data` function from `Dictionary` to `Variant` in Constant node.