### PR TITLE
Add missing bbcode

### DIFF
--- a/addons/gaea/graph/components/argument_editors/range_argument_editor.tscn
+++ b/addons/gaea/graph/components/argument_editors/range_argument_editor.tscn
@@ -24,6 +24,7 @@ script = ExtResource("1_xfmar")
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/normal = SubResource("StyleBoxEmpty_3xeyn")
+bbcode_enabled = true
 text = "Label"
 fit_content = true
 


### PR DESCRIPTION
I think close #347 all argument editor have bbcode and a richtextlabel except the range  node for the min/max text but I think it's OK