### PR TITLE
Remove old saved properties from `BoolArgumentEditor`

### DIFF
--- a/addons/gaea/graph/components/argument_editors/boolean_argument_editor.tscn
+++ b/addons/gaea/graph/components/argument_editors/boolean_argument_editor.tscn
@@ -5,8 +5,6 @@
 
 [node name="BaseParameter" instance=ExtResource("1_xkrhe")]
 script = ExtResource("2_pbrqj")
-add_input_slot = true
-input_type = 6
 
 [node name="CheckBox" type="CheckBox" parent="." index="1"]
 layout_mode = 2


### PR DESCRIPTION
The boolean argument editor had some old saved property, this PR remove them