### PR TITLE
Update enum cases to uppercase

### DIFF
--- a/addons/gaea/graph/graph_nodes/generic_classes/number_operation.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/number_operation.gd
@@ -5,27 +5,27 @@ extends GaeaNodeResource
 
 
 enum Operation {
-	Add,
-	Subtract,
-	Multiply,
-	Divide,
-	#Remainder,
-	Power,
-	Max,
-	Min,
-	#Snapped,
-	Abs,
-	Ceil,
-	Clamp,
-	Floor,
-	Round,
-	#Lerp,
-	#Log,
-	Remap,
-	Sign,
-	Smoothstep,
-	Step,
-	Wrap,
+	ADD,
+	SUBTRACT,
+	MULTIPLY,
+	DIVIDE,
+	#REMAINDER,
+	POWER,
+	MAX,
+	MIN,
+	#SNAPPED,
+	ABS,
+	CEIL,
+	CLAMP,
+	FLOOR,
+	ROUND,
+	#LERP,
+	#LOG,
+	REMAP,
+	SIGN,
+	SMOOTHSTEP,
+	STEP,
+	WRAP,
 }
 
 class Definition:
@@ -44,31 +44,31 @@ var OPERATION_DEFINITIONS: Dictionary[Operation, Definition] : get = _get_operat
 
 func _get_description() -> String:
 	match get_enum_selection(0):
-		Operation.Power:
+		Operation.POWER:
 			return "Returns the value of [param base] raised to the power of [param exp]."
-		Operation.Max:
+		Operation.MAX:
 			return "Returns the maximum between [param a] and [param b]."
-		Operation.Min:
+		Operation.MIN:
 			return "Returns the minimum between [param a] and [param b]."
-		Operation.Abs:
+		Operation.ABS:
 			return "Returns the absolute value of [param a]."
-		Operation.Clamp:
+		Operation.CLAMP:
 			return "Constrains [param a] to lie between [param min] and [param max] (inclusive)."
-		Operation.Remap:
+		Operation.REMAP:
 			return "Maps [param a] from range [code][istart, istop][/code] to [code][ostart, ostop][/code]."
-		Operation.Ceil:
+		Operation.CEIL:
 			return "Finds the nearest integer that is greater or equal to [param a]."
-		Operation.Floor:
+		Operation.FLOOR:
 			return "Finds the nearest integer that is lower or equal to [param a]."
-		Operation.Round:
+		Operation.ROUND:
 			return "Finds the nearest integer to [param a]."
-		Operation.Sign:
+		Operation.SIGN:
 			return "Returns [code]-1[/code] for negative numbers, [code]1[/code] for positive numbers and [code]0[/code] for zeroes."
-		Operation.Smoothstep:
+		Operation.SMOOTHSTEP:
 			return "Returns [code]0[/code] if [param a] < [param from], [code]1[/code] if [param a] > [param to], otherwise returns an interpolated value between [code]0[/code] and [code]1[/code]."
-		Operation.Step:
+		Operation.STEP:
 			return "Returns [code]0[/code] if [param a] < [param edge], otherwise [code]1[/code]."
-		Operation.Wrap:
+		Operation.WRAP:
 			return "Wraps [param a] between [param min] and [param max]."
 	return super()
 
@@ -147,51 +147,51 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 		return OPERATION_DEFINITIONS
 
 	OPERATION_DEFINITIONS = {
-		Operation.Add:
+		Operation.ADD:
 			Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
-		Operation.Subtract:
+		Operation.SUBTRACT:
 			Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
-		Operation.Multiply:
+		Operation.MULTIPLY:
 			Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
-		Operation.Divide:
+		Operation.DIVIDE:
 			Definition.new([&"a", &"b"], "a / b", func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b),
-		#Operation.Remainder:
+		#Operation.REMAINDER:
 			#Definition.new([&"a", &"b"], "a % b", func(a: float, b: float): return 0.0 if is_zero_approx(b) else fmod(a, b)),
-		Operation.Power:
+		Operation.POWER:
 			Definition.new([&"base", &"exp"], "base ** exp", pow),
-		Operation.Max:
+		Operation.MAX:
 			Definition.new([&"a",&"b"], "max(a, b)", max),
-		Operation.Min:
+		Operation.MIN:
 			Definition.new([&"a",&"b"], "min(a, b)", min),
-		#Operation.Snapped:
+		#Operation.SNAPPED:
 			#Definition.new([&"a", "Step"], "snapped(a, step)", snapped),
-		Operation.Abs:
+		Operation.ABS:
 			Definition.new([&"a"], "abs(a)", abs),
-		Operation.Ceil:
+		Operation.CEIL:
 			Definition.new([&"a"], "ceil(a)", ceil),
-		Operation.Floor:
+		Operation.FLOOR:
 			Definition.new([&"a"], "floor(a)", floor),
-		Operation.Round:
+		Operation.ROUND:
 			Definition.new([&"a"], "round(a)", round),
-		Operation.Clamp:
+		Operation.CLAMP:
 			Definition.new([&"a", &"min", &"max"], "clamp(a, min, max)", clamp),
-		#Operation.Lerp:
+		#Operation.LERP:
 			#Definition.new([&"from", &"to", &"weight"], "lerpf(from, to, weight)", lerpf),
-		#Operation.Log:
+		#Operation.LOG:
 			#Definition.new([&"a"], "log(a)", log),
-		Operation.Remap:
+		Operation.REMAP:
 			Definition.new(
 				[&"a", &"in_start", &"in_stop", &"out_start", &"out_stop"],
 				"remap(a, ...)",
 				remap
 			),
-		Operation.Sign:
+		Operation.SIGN:
 			Definition.new([&"a"], "sign(a)", sign),
-		Operation.Smoothstep:
+		Operation.SMOOTHSTEP:
 			Definition.new([&"from", &"to", &"a"], "smoothstep(from, to, a)", smoothstep),
-		Operation.Step:
+		Operation.STEP:
 			Definition.new([&"a", &"edge"], "step(a, edge)", func(a, edge): return 0 if a < edge else 1),
-		Operation.Wrap:
+		Operation.WRAP:
 			Definition.new([&"a", &"min", &"max"], "wrap(a, min, max)", wrap),
 	}
 	return OPERATION_DEFINITIONS

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -517,7 +517,7 @@ func connection_idx_to_output(output_idx: int) -> StringName:
 #region Logging
 # If enabled in [member GaeaData.logging], log the execution information. (See [enum GaeaData.Log]).
 func _log_execute(message:String, area:AABB, generator_data:GaeaData):
-	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.Execute > 0:
+	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.EXECUTE > 0:
 		message = message.strip_edges()
 		message = message if message == "" else message + " "
 		print("Execute   |   %sArea %s on %s" % [message, area, _get_title()])
@@ -525,7 +525,7 @@ func _log_execute(message:String, area:AABB, generator_data:GaeaData):
 
 # If enabled in [member GaeaData.logging], log the layer information. (See [enum GaeaData.Log]).
 func _log_layer(message:String, layer:int, generator_data:GaeaData):
-	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.Execute > 0:
+	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.EXECUTE > 0:
 		message = message.strip_edges()
 		message = message if message == "" else message + " "
 		print("Execute   |   %sLayer %d on %s" % [message, layer, _get_title()])
@@ -533,20 +533,20 @@ func _log_layer(message:String, layer:int, generator_data:GaeaData):
 
 # If enabled in [member GaeaData.logging], log the traverse information. (See [enum GaeaData.Log]).
 func _log_traverse(generator_data:GaeaData):
-	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.Traverse > 0:
+	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.TRAVERSE > 0:
 		print("Traverse  |   %s" % [_get_title()])
 
 
 ## If enabled in [member GaeaData.logging], log the data information. (See [enum GaeaData.Log]).
 ## Should be called in [method _get_data]
 func _log_data(output_port: StringName, generator_data:GaeaData):
-	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.Data > 0:
+	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.DATA > 0:
 		print("Data      |   %s from port &\"%s\"" % [_get_title(), output_port])
 
 
 # If enabled in [member GaeaData.logging], log the argument information. (See [enum GaeaData.Log]).
 func _log_arg(arg:String, generator_data:GaeaData):
-	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.Args > 0:
+	if is_instance_valid(generator_data) and generator_data.logging & GaeaData.Log.ARGS > 0:
 		print("Arg       |   %s on %s" % [arg, _get_title()])
 
 

--- a/addons/gaea/graph/graph_nodes/root/data/operations/datas/datas_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/operations/datas/datas_operation.gd
@@ -5,10 +5,10 @@ extends GaeaNodeResource
 
 
 enum Operation {
-	Add,
-	Subtract,
-	Multiply,
-	Divide,
+	ADD,
+	SUBTRACT,
+	MULTIPLY,
+	DIVIDE,
 }
 
 class Definition:
@@ -34,13 +34,13 @@ func _get_description() -> String:
 		return "Operation between 2 data grids."
 
 	match get_enum_selection(0):
-		Operation.Add:
+		Operation.ADD:
 			return "Adds all cells in [param B] to all cells in [param A]."
-		Operation.Subtract:
+		Operation.SUBTRACT:
 			return "Adds all cells in [param B] from all cells in [param A]."
-		Operation.Multiply:
+		Operation.MULTIPLY:
 			return "Multiplies all cells in [param B] with all cells in [param A]."
-		Operation.Divide:
+		Operation.DIVIDE:
 			return "Adds all cells in [param A] by all cells in [param B]."
 		_:
 			return super()
@@ -115,13 +115,13 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 		return OPERATION_DEFINITIONS
 
 	OPERATION_DEFINITIONS = {
-		Operation.Add:
+		Operation.ADD:
 			Definition.new([&"a", &"b"], "A + B", func(a: Variant, b: Variant): return a + b),
-		Operation.Subtract:
+		Operation.SUBTRACT:
 			Definition.new([&"a", &"b"], "A - B", func(a: Variant, b: Variant): return a - b),
-		Operation.Multiply:
+		Operation.MULTIPLY:
 			Definition.new([&"a", &"b"], "A * B", func(a: Variant, b: Variant): return a * b),
-		Operation.Divide:
+		Operation.DIVIDE:
 			Definition.new([&"a", &"b"], "A / B", func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b)
 	}
 	return OPERATION_DEFINITIONS

--- a/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
@@ -4,10 +4,10 @@ extends GaeaNodeVectorBase
 ## Base class for operations between 2 vectors.
 
 enum Operation {
-	Add,
-	Subtract,
-	Multiply,
-	Divide,
+	ADD,
+	SUBTRACT,
+	MULTIPLY,
+	DIVIDE,
 }
 
 
@@ -33,13 +33,13 @@ func _get_description() -> String:
 		return "Operation between 2 [code]Vector[/code]s."
 
 	match get_enum_selection(1):
-		Operation.Add:
+		Operation.ADD:
 			return "Sums 2 [code]%s[/code]s." % _get_enum_option_display_name(0, get_enum_selection(0))
-		Operation.Subtract:
+		Operation.SUBTRACT:
 			return "Subtracts 2 [code]%s[/code]s." % _get_enum_option_display_name(0, get_enum_selection(0))
-		Operation.Multiply:
+		Operation.MULTIPLY:
 			return "Multiplies 2 [code]%s[/code]s together." % _get_enum_option_display_name(0, get_enum_selection(0))
-		Operation.Divide:
+		Operation.DIVIDE:
 			return "Divides 2 [code]%s[/code]s together." % _get_enum_option_display_name(0, get_enum_selection(0))
 	return ""
 
@@ -130,13 +130,13 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 		return OPERATION_DEFINITIONS
 
 	OPERATION_DEFINITIONS = {
-		Operation.Add:
+		Operation.ADD:
 			Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
-		Operation.Subtract:
+		Operation.SUBTRACT:
 			Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
-		Operation.Multiply:
+		Operation.MULTIPLY:
 			Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
-		Operation.Divide:
+		Operation.DIVIDE:
 			Definition.new([&"a", &"b"], "a / b", func(a: Variant, b: Variant): return 0 if b.is_zero_approx() else a / b),
 	}
 	return OPERATION_DEFINITIONS

--- a/addons/gaea/resources/gaea_data.gd
+++ b/addons/gaea/resources/gaea_data.gd
@@ -12,11 +12,11 @@ signal layer_count_modified
 
 ## Flags used for determining what to log during generation. See [member logging].
 enum Log {
-	None=0,
-	Execute=1, ## Log execution data such as current area & current layer.
-	Traverse=2, ## Log traverse data (which nodes are being traversed in the graph).
-	Data=4,  ## Log which data is being generated from which port.
-	Args=8  ## Log which arguments are being grabbed.
+	NONE=0,
+	EXECUTE=1, ## Log execution data such as current area & current layer.
+	TRAVERSE=2, ## Log traverse data (which nodes are being traversed in the graph).
+	DATA=4,  ## Log which data is being generated from which port.
+	ARGS=8  ## Log which arguments are being grabbed.
 }
 
 ## [GaeaLayer]s as seen in the Output node in the graph. Can be used
@@ -28,7 +28,7 @@ enum Log {
 		emit_changed()
 @export_group("Debug")
 ## Selection of what to print in the Output console during generation. See [enum Log].
-@export_flags("Execute", "Traverse", "Data", "Args") var logging:int = Log.None
+@export_flags("Execute", "Traverse", "Data", "Args") var logging:int = Log.NONE
 ## List of all connections between nodes. The dictionaries contain the following properties:
 ## [codeblock]
 ## {


### PR DESCRIPTION
Standardize the naming convention of enum cases and logging flags to uppercase for consistency and clarity.