### PR TITLE
Add documentation button to GaeaGraphNode

### DIFF
--- a/addons/gaea/graph/graph_nodes/node.gd
+++ b/addons/gaea/graph/graph_nodes/node.gd
@@ -42,6 +42,16 @@ func _ready() -> void:
 	connections_updated.connect(_update_arguments_visibility)
 	removed.connect(_on_removed)
 
+	if Engine.get_version_info().hex >= 0x040500 and not resource is GaeaNodeReroute:
+		var script = resource.get_script()
+		if is_instance_valid(script):
+			var documentation_button = Button.new()
+			documentation_button.icon = EditorInterface.get_editor_theme().get_icon(&"HelpSearch", &"EditorIcons")
+			documentation_button.flat = true
+			get_titlebar_hbox().add_child(documentation_button)
+			documentation_button.pressed.connect(_open_node_documentation)
+			tree_exiting.connect(documentation_button.pressed.disconnect.bind(_open_node_documentation))
+
 
 ## Initializes the node with a preview if needed, a salt value and instantiates all the
 ## [GaeaGraphNodeArgumentEditor] and [GaeaGraphNodeOutput] nodes.
@@ -336,6 +346,16 @@ func _make_custom_tooltip(for_text: String) -> Object:
 	rich_text_label.fit_content = true
 	rich_text_label.custom_minimum_size.x = 256.0
 	return rich_text_label
+
+
+func _open_node_documentation():
+	var script = resource.get_script()
+	if not is_instance_valid(script):
+		return
+
+	var ressource_class_name = (script as GDScript).get_global_name()
+	var script_editor = EditorInterface.get_script_editor()
+	script_editor.goto_help("class_name:%s" % ressource_class_name)
 
 
 ## Sets whether or not this node has finished its loading process.

--- a/addons/gaea/graph/graph_nodes/node.gd
+++ b/addons/gaea/graph/graph_nodes/node.gd
@@ -38,19 +38,18 @@ func _ready() -> void:
 
 	if is_instance_valid(resource):
 		set_tooltip_text("tooltip")
+		if Engine.get_version_info().hex >= 0x040500 and not resource is GaeaNodeReroute:
+			var script = resource.get_script()
+			if is_instance_valid(script):
+				var documentation_button := Button.new()
+				documentation_button.icon = EditorInterface.get_editor_theme().get_icon(&"HelpSearch", &"EditorIcons")
+				documentation_button.flat = true
+				get_titlebar_hbox().add_child(documentation_button)
+				documentation_button.pressed.connect(_open_node_documentation)
+				tree_exiting.connect(documentation_button.pressed.disconnect.bind(_open_node_documentation))
 
 	connections_updated.connect(_update_arguments_visibility)
 	removed.connect(_on_removed)
-
-	if Engine.get_version_info().hex >= 0x040500 and not resource is GaeaNodeReroute:
-		var script = resource.get_script()
-		if is_instance_valid(script):
-			var documentation_button = Button.new()
-			documentation_button.icon = EditorInterface.get_editor_theme().get_icon(&"HelpSearch", &"EditorIcons")
-			documentation_button.flat = true
-			get_titlebar_hbox().add_child(documentation_button)
-			documentation_button.pressed.connect(_open_node_documentation)
-			tree_exiting.connect(documentation_button.pressed.disconnect.bind(_open_node_documentation))
 
 
 ## Initializes the node with a preview if needed, a salt value and instantiates all the
@@ -353,9 +352,9 @@ func _open_node_documentation():
 	if not is_instance_valid(script):
 		return
 
-	var ressource_class_name = (script as GDScript).get_global_name()
-	var script_editor = EditorInterface.get_script_editor()
-	script_editor.goto_help("class_name:%s" % ressource_class_name)
+	var resource_class_name := (script as GDScript).get_global_name()
+	var script_editor := EditorInterface.get_script_editor()
+	script_editor.goto_help("class_name:%s" % resource_class_name)
 
 
 ## Sets whether or not this node has finished its loading process.


### PR DESCRIPTION
## Description

Closes #337

This PR adds a **documentation button** to `GaeaGraphNode`.

The button provides quick access to relevant documentation and is **only visible when using Godot 4.5 or later**, due to [Godot issue #72406](https://github.com/godotengine/godot/issues/72406) which affects documentation generation in earlier versions.

4.5+
![image](https://github.com/user-attachments/assets/09edaa8b-086b-4cad-8fb2-1e0b0ceaf05a)

4.4.1
![image](https://github.com/user-attachments/assets/12203368-3060-4e0b-9643-d35b08b56c29)

