### PR TITLE
Change the way parameter names are edited

### DIFF
--- a/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
@@ -3,23 +3,66 @@ extends GaeaGraphNodeArgumentEditor
 class_name GaeaParameterNameArgumentEditor
 
 
-@onready var line_edit: LineEdit = $LineEdit
+@onready var name_label: Label = $NameLabel
+@onready var _edit_button: Button = $EditButton
+
 
 
 func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
 	await super()
+	
+	_edit_button.icon = EditorInterface.get_base_control().get_theme_icon(&"Edit", &"EditorIcons")
 
-	line_edit.text_changed.connect(argument_value_changed.emit)
 
 func get_arg_value() -> String:
 	if super() != null:
 		return super()
-	return line_edit.text
+	return name_label.text
 
 
 func set_arg_value(new_value: Variant) -> void:
 	if typeof(new_value) not in [TYPE_STRING, TYPE_STRING_NAME]:
 		return
-	line_edit.text = new_value
+	
+	name_label.text = new_value
+
+
+func _on_edit_button_pressed() -> void:
+	var line_edit: LineEdit = LineEdit.new()
+	line_edit.select_all_on_focus = true
+	line_edit.text = name_label.text
+	line_edit.expand_to_text_length = true
+	line_edit.text_changed.connect(_on_line_edit_text_changed.bind(line_edit))
+	line_edit.text_submitted.connect(_on_line_edit_text_submitted.bind(line_edit))
+	line_edit.focus_exited.connect(line_edit.queue_free)
+	line_edit.position = graph_node.get_parent().get_local_mouse_position()
+	graph_node.get_parent().add_child(line_edit)
+	line_edit.grab_focus()
+
+
+func _on_line_edit_text_changed(new_text: String, line_edit: LineEdit) -> void:
+	if (graph_node.generator.data.parameters.has(new_text) and new_text != name_label.text) or not new_text.is_valid_identifier():
+		line_edit.add_theme_color_override(&"font_color", EditorInterface.get_base_control().get_theme_color(&"error_color", &"Editor"))
+	else:
+		line_edit.remove_theme_color_override(&"font_color")
+
+
+func _on_line_edit_text_submitted(new_text: String, line_edit: LineEdit) -> void:
+	if new_text == name_label.text:
+		line_edit.queue_free()
+		return
+		
+	if not new_text.is_valid_ascii_identifier():
+		push_error("Parameter name '%s' is not a valid identifier." % new_text)
+		return
+		
+	if graph_node.generator.data.parameters.has(new_text):
+		push_error("Parameter name '%s' matches an already existing parameter." % new_text)
+		return
+		
+	name_label.text = new_text
+	argument_value_changed.emit(new_text)
+	line_edit.queue_free()
+	

--- a/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
@@ -63,6 +63,6 @@ func _on_line_edit_text_submitted(new_text: String, line_edit: LineEdit) -> void
 		return
 		
 	name_label.text = new_text
+	graph_node.auto_shrink.call_deferred()
 	argument_value_changed.emit(new_text)
 	line_edit.queue_free()
-	

--- a/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
@@ -12,7 +12,7 @@ func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
 	await super()
-	
+
 	_edit_button.icon = EditorInterface.get_base_control().get_theme_icon(&"Edit", &"EditorIcons")
 
 
@@ -25,7 +25,7 @@ func get_arg_value() -> String:
 func set_arg_value(new_value: Variant) -> void:
 	if typeof(new_value) not in [TYPE_STRING, TYPE_STRING_NAME]:
 		return
-	
+
 	name_label.text = new_value
 
 
@@ -53,15 +53,15 @@ func _on_line_edit_text_submitted(new_text: String, line_edit: LineEdit) -> void
 	if new_text == name_label.text:
 		line_edit.queue_free()
 		return
-		
+
 	if not new_text.is_valid_ascii_identifier():
 		push_error("Parameter name '%s' is not a valid identifier." % new_text)
 		return
-		
+
 	if graph_node.generator.data.parameters.has(new_text):
 		push_error("Parameter name '%s' matches an already existing parameter." % new_text)
 		return
-		
+
 	name_label.text = new_text
 	graph_node.auto_shrink.call_deferred()
 	argument_value_changed.emit(new_text)

--- a/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.tscn
+++ b/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.tscn
@@ -10,7 +10,13 @@ script = ExtResource("2_ofrdj")
 [node name="Label" parent="." index="0"]
 visible = false
 
-[node name="LineEdit" type="LineEdit" parent="." index="1"]
+[node name="NameLabel" type="Label" parent="." index="1"]
 layout_mode = 2
 size_flags_horizontal = 3
-select_all_on_focus = true
+
+[node name="EditButton" type="Button" parent="." index="2"]
+layout_mode = 2
+tooltip_text = "Edit parameter name."
+flat = true
+
+[connection signal="pressed" from="EditButton" to="." method="_on_edit_button_pressed"]

--- a/addons/gaea/graph/graph_nodes/generic_classes/parameter_node.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/parameter_node.gd
@@ -50,6 +50,7 @@ func _on_removed() -> void:
 func _on_argument_value_changed(value: Variant, _node: GaeaGraphNodeArgumentEditor, arg_name: String) -> void:
 	if arg_name != "name" and value is not String:
 		return
+		
 
 	if value == previous_name:
 		return

--- a/addons/gaea/graph/graph_nodes/generic_classes/parameter_node.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/parameter_node.gd
@@ -7,7 +7,6 @@ var hint: PropertyHint
 var hint_string: String
 
 var previous_name: String
-var _is_invalid_name: bool = false
 
 
 func _on_added() -> void:
@@ -47,28 +46,9 @@ func _on_removed() -> void:
 	generator.data.notify_property_list_changed()
 
 
-func get_save_data() -> Dictionary:
-	var save_data := super()
-	if _is_invalid_name:
-		if previous_name.is_empty():
-			previous_name = resource.get_argument_default_value(&"name")
-		save_data.get(&"arguments").set(&"name", previous_name)
-	return save_data
 
-
-func _on_argument_value_changed(value: Variant, node: GaeaGraphNodeArgumentEditor, arg_name: String) -> void:
+func _on_argument_value_changed(value: Variant, _node: GaeaGraphNodeArgumentEditor, arg_name: String) -> void:
 	if arg_name != "name" and value is not String:
-		return
-
-	if value.is_empty():
-		node.line_edit.text = previous_name
-		return
-
-	node.line_edit.remove_theme_color_override("font_color")
-	_is_invalid_name = false
-	if generator.data.parameters.has(value) and value != previous_name:
-		_is_invalid_name = true
-		node.line_edit.add_theme_color_override("font_color", Color.RED)
 		return
 
 	if value == previous_name:

--- a/addons/gaea/graph/graph_nodes/generic_classes/parameter_node.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/parameter_node.gd
@@ -24,13 +24,17 @@ func _on_added() -> void:
 	if not _finished_loading:
 		push_error("Something went wrong during loading of the variable node '%s'" % resource.get_title())
 
+	_add_parameter.call_deferred()
+
+
+func _add_parameter() -> void:
 	previous_name = get_arg_value(&"name")
 
-	if generator.data.parameters.has(get_arg_value(&"name")):
+	if generator.data.parameters.has(previous_name):
 		return
 
-	generator.data.parameters[get_arg_value(&"name")] = {
-		"name": get_arg_value(&"name"),
+	generator.data.parameters[previous_name] = {
+		"name": previous_name,
 		"type": resource.type,
 		"hint": resource.hint,
 		"hint_string": resource.hint_string,
@@ -50,7 +54,7 @@ func _on_removed() -> void:
 func _on_argument_value_changed(value: Variant, _node: GaeaGraphNodeArgumentEditor, arg_name: String) -> void:
 	if arg_name != "name" and value is not String:
 		return
-		
+
 
 	if value == previous_name:
 		return
@@ -70,6 +74,8 @@ func _get_default_value(for_type: Variant.Type) -> Variant:
 	match for_type:
 		TYPE_FLOAT, TYPE_INT:
 			return 0
+		TYPE_BOOL:
+			return false
 		TYPE_VECTOR2:
 			return Vector2(0, 0)
 		TYPE_VECTOR2I:


### PR DESCRIPTION
This PR changes the way parameter names are edited to disallow invalid names, improve clarity on why a name is being rejected and make accidentally changing the name harder.

It also forces parameter names to be valid identifiers (can't start with a digit; and can only have letters, digits and _). Previously existing names won't change but future ones will _have_ to be valid identifiers.

Finally, it makes parameter nodes adjust to the size of their name label.


![Peek 2025-05-07 19-43](https://github.com/user-attachments/assets/8d6fe18e-52dd-455f-9922-139341814362)

Here are the errors I got when trying to submit the invalid (red) names:
![image](https://github.com/user-attachments/assets/8695f2c2-56e8-4432-9cbc-d209f4e1aa69)
