### PR TITLE
Fix `TilemapGaeaRenderer` rendering wrong terrain

### DIFF
--- a/addons/gaea/nodes/renderers/tilemap_renderer.gd
+++ b/addons/gaea/nodes/renderers/tilemap_renderer.gd
@@ -10,12 +10,12 @@ extends GaeaRenderer
 
 
 func _render(grid: GaeaGrid) -> void:
-	var terrains: Dictionary[TileMapGaeaMaterial, Array]
 
 	if tile_map_layers.size() == 0:
 		push_warning("No tile map layers set in the renderer")
 
 	for layer_idx in grid.get_layers_count():
+		var terrains: Dictionary[TileMapGaeaMaterial, Array] = {}
 		if tile_map_layers.size() <= layer_idx or not is_instance_valid(tile_map_layers.get(layer_idx)):
 			continue
 

--- a/addons/gaea/nodes/renderers/tilemap_renderer.gd
+++ b/addons/gaea/nodes/renderers/tilemap_renderer.gd
@@ -10,7 +10,6 @@ extends GaeaRenderer
 
 
 func _render(grid: GaeaGrid) -> void:
-
 	if tile_map_layers.size() == 0:
 		push_warning("No tile map layers set in the renderer")
 


### PR DESCRIPTION
The terrains dictionary was not cleared between layers

See https://github.com/gaea-godot/gaea/discussions/395