### PR TITLE
Add Operation node checks and fix `GaeaNodeDataOp`

### DIFF
--- a/addons/gaea/graph/graph_nodes/root/data/operations/scalar/data_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/operations/scalar/data_operation.gd
@@ -72,5 +72,5 @@ func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant
 	for cell: Vector3i in input_grid:
 		var cell_args = args.duplicate()
 		cell_args.insert(grid_value_pos, input_grid[cell])
-		new_grid.set(cell, 99)
+		new_grid.set(cell, operation_definition.conversion.callv(cell_args))
 	return new_grid

--- a/addons/gaea/graph/graph_nodes/root/data/operations/scalar/data_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/operations/scalar/data_operation.gd
@@ -21,6 +21,8 @@ func _get_description() -> String:
 			return "Adds a [code]float[/code] number with all cells in [param A]."
 		Operation.DIVIDE:
 			return "Divides all cells in [param A] by a [code]float[/code] number."
+		Operation.POWER:
+			return super().replace("base", "a") + "\n\nOperates over all cells of [param A], [param a] being the cells' value."
 		_:
 			return super() + "\n\nOperates over all cells of [param A], [param a] being the cells' value."
 
@@ -49,7 +51,8 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 		definition.output = definition.output.replace(" a", " A")
 		definition.output = definition.output.replace("a,", "A,")
 		definition.output = definition.output.replace("(a)", "(A)")
-	definitions.erase(Operation.POWER)
+		definition.output = definition.output.replace("base", "A")
+	definitions[Operation.POWER].args[0] = &"a"
 	return definitions
 
 
@@ -64,7 +67,10 @@ func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant
 			continue
 		args.append(_get_arg(arg_name, area, graph))
 	var new_grid: Dictionary[Vector3i, float]
+	var grid_value_pos: int = _get_arguments_list().find(&"a")
 
 	for cell: Vector3i in input_grid:
-		new_grid.set(cell, operation_definition.conversion.callv([input_grid[cell]] + args))
+		var cell_args = args.duplicate()
+		cell_args.insert(grid_value_pos, input_grid[cell])
+		new_grid.set(cell, 99)
 	return new_grid

--- a/testing/graph_nodes/operations/data_op.gd
+++ b/testing/graph_nodes/operations/data_op.gd
@@ -1,0 +1,30 @@
+extends "res://testing/graph_nodes/operations/float_op.gd"
+
+
+
+func before():
+	node = GaeaNodeDataOp.new()
+
+
+func _assert_operation_result(args: Array[Variant], expected: float) -> void:
+	for i in node.get_arguments_list().size():
+		if node.get_argument_type(node.get_arguments_list()[i]) == GaeaValue.Type.DATA:
+			args[i] = {Vector3i.ZERO: args[i], Vector3i(1, 1, 0): args[i], Vector3i(1, 0, 0): args[i], Vector3i(0, 1, 0): args[i]}
+		node.set_argument_value(node.get_arguments_list()[i], args[i])
+	var grid: Dictionary = node._get_data(&"result", AABB(), null)
+	assert_dict(grid)\
+		.override_failure_message("[b]GaeaNodeDataOp[/b] returned an empty grid with operation [b]%s[/b]."
+			% GaeaNodeDataOp.Operation.keys()[node.get_enum_selection(0)])\
+		.is_not_empty()
+
+	for cell in grid:
+		var result: float = grid.get(cell)
+		assert_float(result)\
+			.override_failure_message(
+				"[b]GaeaNodeDataOp[/b] returned an unexpected value with operation [b]%s[/b]."
+				% GaeaNodeDataOp.Operation.keys()[node.get_enum_selection(0)]
+				)\
+			.append_failure_message(
+				"Arguments: %s\n Expected result: %s\n Returned result: %s\n At cell: %s"
+				 % [args, expected, result, cell])\
+			.is_equal(expected)

--- a/testing/graph_nodes/operations/data_op.gd.uid
+++ b/testing/graph_nodes/operations/data_op.gd.uid
@@ -1,0 +1,1 @@
+uid://ccr7prntimb81

--- a/testing/graph_nodes/operations/float_op.gd
+++ b/testing/graph_nodes/operations/float_op.gd
@@ -1,0 +1,59 @@
+extends GdUnitTestSuite
+
+
+var node: GaeaNodeFloatOp
+
+class Result:
+	var inputs: Array[float]
+	var expected: float
+	func _init(inp, expc) -> void:
+		inputs = inp
+		expected = expc
+
+# Of the form Operation: [tests]
+static var EXPECTED: Dictionary[GaeaNodeFloatOp.Operation, Array] = {
+	GaeaNodeFloatOp.Operation.ADD: 
+		[Result.new([2.0, 1.0], 3.0), Result.new([1.0, -0.5], 0.5)],
+	GaeaNodeFloatOp.Operation.SUBTRACT: 
+		[Result.new([2.0, 1.0], 1.0), Result.new([1.0, -0.5], 1.5)],
+}
+
+
+func before() -> void:
+	node = GaeaNodeFloatOp.new()
+
+
+func test_add() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.ADD)
+	node.set_argument_value(&"a", 2.0)
+	node.set_argument_value(&"b", 1.0)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(3.0)
+	node.set_argument_value(&"a", -0.5)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(0.5)
+
+
+func test_subtract() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.SUBTRACT)
+	node.set_argument_value(&"a", 2.0)
+	node.set_argument_value(&"b", 1.0)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(1.0)
+	node.set_argument_value(&"a", -0.5)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(-1.5)
+
+
+func test_multiply() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.MULTIPLY)
+	node.set_argument_value(&"a", 2.0)
+	node.set_argument_value(&"b", 4.0)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(8.0)
+	node.set_argument_value(&"a", -0.5)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(-2.0)
+
+
+func test_divide() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.DIVIDE)
+	node.set_argument_value(&"a", 4.0)
+	node.set_argument_value(&"b", 2.0)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(2.0)
+	node.set_argument_value(&"a", -5.0)
+	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(-2.5)

--- a/testing/graph_nodes/operations/float_op.gd
+++ b/testing/graph_nodes/operations/float_op.gd
@@ -1,24 +1,9 @@
-extends GdUnitTestSuite
+extends "res://testing/graph_nodes/operations/num_op.gd"
 
 
-var node: GaeaNodeFloatOp
 
-
-func before() -> void:
+func before():
 	node = GaeaNodeFloatOp.new()
-
-
-func _assert_operation_result(args: Array[float], expected: float) -> void:
-	for i in node.get_arguments_list().size():
-		node.set_argument_value(node.get_arguments_list()[i], args[i])
-	var result: float = node._get_data(&"result", AABB(), null)
-	assert_float(result)\
-		.override_failure_message(
-			"[b]GaeaNodeFloatOp[/b] returned an unexpected value with operation [b]%s[/b]."
-			% GaeaNodeFloatOp.Operation.keys()[node.get_enum_selection(0)]
-			)\
-		.append_failure_message("Arguments: %s\n Expected result: %s\n Returned result: %s" % [args, expected, result])\
-		.is_equal(expected)
 
 
 func test_add() -> void:

--- a/testing/graph_nodes/operations/float_op.gd
+++ b/testing/graph_nodes/operations/float_op.gd
@@ -3,57 +3,112 @@ extends GdUnitTestSuite
 
 var node: GaeaNodeFloatOp
 
-class Result:
-	var inputs: Array[float]
-	var expected: float
-	func _init(inp, expc) -> void:
-		inputs = inp
-		expected = expc
-
-# Of the form Operation: [tests]
-static var EXPECTED: Dictionary[GaeaNodeFloatOp.Operation, Array] = {
-	GaeaNodeFloatOp.Operation.ADD: 
-		[Result.new([2.0, 1.0], 3.0), Result.new([1.0, -0.5], 0.5)],
-	GaeaNodeFloatOp.Operation.SUBTRACT: 
-		[Result.new([2.0, 1.0], 1.0), Result.new([1.0, -0.5], 1.5)],
-}
-
 
 func before() -> void:
 	node = GaeaNodeFloatOp.new()
 
 
+func _assert_operation_result(args: Array[float], expected: float) -> void:
+	for i in node.get_arguments_list().size():
+		node.set_argument_value(node.get_arguments_list()[i], args[i])
+	var result: float = node._get_data(&"result", AABB(), null)
+	assert_float(result)\
+		.override_failure_message(
+			"[b]GaeaNodeFloatOp[/b] returned an unexpected value with operation [b]%s[/b]."
+			% GaeaNodeFloatOp.Operation.keys()[node.get_enum_selection(0)]
+			)\
+		.append_failure_message("Arguments: %s\n Expected result: %s\n Returned result: %s" % [args, expected, result])\
+		.is_equal(expected)
+
+
 func test_add() -> void:
 	node.set_enum_value(0, GaeaNodeFloatOp.Operation.ADD)
-	node.set_argument_value(&"a", 2.0)
-	node.set_argument_value(&"b", 1.0)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(3.0)
-	node.set_argument_value(&"a", -0.5)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(0.5)
+	_assert_operation_result([2.0, 1.0], 3.0)
+	_assert_operation_result([1.0, -0.5], 0.5)
 
 
 func test_subtract() -> void:
 	node.set_enum_value(0, GaeaNodeFloatOp.Operation.SUBTRACT)
-	node.set_argument_value(&"a", 2.0)
-	node.set_argument_value(&"b", 1.0)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(1.0)
-	node.set_argument_value(&"a", -0.5)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(-1.5)
+	_assert_operation_result([2.0, 1.0], 1.0)
+	_assert_operation_result([1.0, -0.5], 1.5)
 
 
 func test_multiply() -> void:
 	node.set_enum_value(0, GaeaNodeFloatOp.Operation.MULTIPLY)
-	node.set_argument_value(&"a", 2.0)
-	node.set_argument_value(&"b", 4.0)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(8.0)
-	node.set_argument_value(&"a", -0.5)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(-2.0)
+	_assert_operation_result([4.0, 2.0], 8.0)
+	_assert_operation_result([4.0, -2.0], -8.0)
 
 
 func test_divide() -> void:
 	node.set_enum_value(0, GaeaNodeFloatOp.Operation.DIVIDE)
-	node.set_argument_value(&"a", 4.0)
-	node.set_argument_value(&"b", 2.0)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(2.0)
-	node.set_argument_value(&"a", -5.0)
-	await assert_float(node._get_data(&"result", AABB(), null)).is_equal(-2.5)
+	_assert_operation_result([2.0, 1.0], 2.0)
+	_assert_operation_result([1.0, -0.5], -2.0)
+
+
+func test_power() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.POWER)
+	_assert_operation_result([2.0, 2.0], 4.0)
+	_assert_operation_result([1.0, 0.0], 1.0)
+	_assert_operation_result([2.0, -1.0], 0.5)
+
+
+func test_min_and_max() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.MAX)
+	_assert_operation_result([1.0, 2.0], 2.0)
+
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.MIN)
+	_assert_operation_result([1.0, 2.0], 1.0)
+
+
+func test_abs() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.ABS)
+	_assert_operation_result([-2.0], 2.0)
+
+
+func test_rounding() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.CEIL)
+	_assert_operation_result([0.5], 1.0)
+
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.FLOOR)
+	_assert_operation_result([0.5], 0.0)
+
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.ROUND)
+	_assert_operation_result([0.4], 0.0)
+	_assert_operation_result([0.6], 1.0)
+
+
+func test_clamp() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.CLAMP)
+	_assert_operation_result([0.5, 0.0, 1.0], 0.5)
+	_assert_operation_result([-INF, 0.0, 1.0], 0.0)
+	_assert_operation_result([INF, 0.0, 1.0], 1.0)
+
+
+func test_remap() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.REMAP)
+	_assert_operation_result([0.5, 0.0, 1.0, 2.0, 4.0], 3.0)
+
+
+func test_sign() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.SIGN)
+	_assert_operation_result([1.0], 1.0)
+	_assert_operation_result([-1.0], -1.0)
+	_assert_operation_result([0.0], 0.0)
+
+
+func test_smoothstep() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.SMOOTHSTEP)
+	_assert_operation_result([0.0, 1.0, 0.9], smoothstep(0.0, 1.0, 0.9))
+
+
+func test_step() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.STEP)
+	_assert_operation_result([0.6, 0.5], 1.0)
+	_assert_operation_result([0.4, 0.5], 0.0)
+	_assert_operation_result([0.5, 0.5], 1.0)
+
+
+func test_wrap() -> void:
+	node.set_enum_value(0, GaeaNodeFloatOp.Operation.WRAP)
+	_assert_operation_result([1.5, 0.0, 1.0], 0.5)
+	_assert_operation_result([0.5, 0.0, 1.0], 0.5)

--- a/testing/graph_nodes/operations/float_op.gd.uid
+++ b/testing/graph_nodes/operations/float_op.gd.uid
@@ -1,0 +1,1 @@
+uid://b0e7o3dtsk6gw

--- a/testing/graph_nodes/operations/int_op.gd
+++ b/testing/graph_nodes/operations/int_op.gd
@@ -1,24 +1,9 @@
-extends GdUnitTestSuite
+extends "res://testing/graph_nodes/operations/num_op.gd"
 
 
-var node: GaeaNodeIntOp
 
-
-func before() -> void:
+func before():
 	node = GaeaNodeIntOp.new()
-
-
-func _assert_operation_result(args: Array[int], expected: int) -> void:
-	for i in node.get_arguments_list().size():
-		node.set_argument_value(node.get_arguments_list()[i], args[i])
-	var result: int = node._get_data(&"result", AABB(), null)
-	assert_int(result)\
-		.override_failure_message(
-			"[b]GaeaNodeIntOp[/b] returned an unexpected value with operation [b]%s[/b]."
-			% GaeaNodeIntOp.Operation.keys()[node.get_enum_selection(0)]
-			)\
-		.append_failure_message("Arguments: %s\n Expected result: %s\n Returned result: %s" % [args, expected, result])\
-		.is_equal(expected)
 
 
 func test_add() -> void:

--- a/testing/graph_nodes/operations/int_op.gd
+++ b/testing/graph_nodes/operations/int_op.gd
@@ -1,0 +1,91 @@
+extends GdUnitTestSuite
+
+
+var node: GaeaNodeIntOp
+
+
+func before() -> void:
+	node = GaeaNodeIntOp.new()
+
+
+func _assert_operation_result(args: Array[int], expected: int) -> void:
+	for i in node.get_arguments_list().size():
+		node.set_argument_value(node.get_arguments_list()[i], args[i])
+	var result: int = node._get_data(&"result", AABB(), null)
+	assert_int(result)\
+		.override_failure_message(
+			"[b]GaeaNodeIntOp[/b] returned an unexpected value with operation [b]%s[/b]."
+			% GaeaNodeIntOp.Operation.keys()[node.get_enum_selection(0)]
+			)\
+		.append_failure_message("Arguments: %s\n Expected result: %s\n Returned result: %s" % [args, expected, result])\
+		.is_equal(expected)
+
+
+func test_add() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.ADD)
+	_assert_operation_result([2, 1], 3)
+	_assert_operation_result([1, -1], 0)
+
+
+func test_subtract() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.SUBTRACT)
+	_assert_operation_result([2, 1], 1)
+	_assert_operation_result([1, -1], 2)
+
+
+func test_multiply() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.MULTIPLY)
+	_assert_operation_result([4, 2], 8)
+	_assert_operation_result([4, -2], -8)
+
+
+func test_divide() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.DIVIDE)
+	_assert_operation_result([2, 1], 2)
+	_assert_operation_result([4, -2], -2)
+
+
+func test_power() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.POWER)
+	_assert_operation_result([2, 2], 4)
+	_assert_operation_result([1, 0], 1)
+
+
+func test_min_and_max() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.MAX)
+	_assert_operation_result([1, 2], 2)
+
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.MIN)
+	_assert_operation_result([1, 2], 1)
+
+
+func test_abs() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.ABS)
+	_assert_operation_result([-2], 2)
+
+
+
+func test_clamp() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.CLAMP)
+	_assert_operation_result([-999, 0, 1], 0)
+	_assert_operation_result([999, 0, 1], 1)
+
+
+func test_sign() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.SIGN)
+	_assert_operation_result([1], 1)
+	_assert_operation_result([-1], -1)
+	_assert_operation_result([0], 0)
+
+
+func test_step() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.STEP)
+	_assert_operation_result([2, 1], 1)
+	_assert_operation_result([0, 1], 0)
+	_assert_operation_result([1, 1], 1)
+
+
+func test_wrap() -> void:
+	node.set_enum_value(0, GaeaNodeIntOp.Operation.WRAP)
+	_assert_operation_result([3, 0, 2], 1)
+	_assert_operation_result([1, 0, 2], 1)

--- a/testing/graph_nodes/operations/int_op.gd.uid
+++ b/testing/graph_nodes/operations/int_op.gd.uid
@@ -1,0 +1,1 @@
+uid://bq03cgemrcy4

--- a/testing/graph_nodes/operations/num_op.gd
+++ b/testing/graph_nodes/operations/num_op.gd
@@ -1,0 +1,21 @@
+extends GdUnitTestSuite
+
+
+var node: GaeaNodeNumOp
+
+
+func before():
+	pass
+
+
+func _assert_operation_result(args: Array[Variant], expected: float) -> void:
+	for i in node.get_arguments_list().size():
+		node.set_argument_value(node.get_arguments_list()[i], args[i])
+	var result: float = node._get_data(&"result", AABB(), null)
+	assert_that(result)\
+		.override_failure_message(
+			"[b]GaeaNodeFloatOp[/b] returned an unexpected value with operation [b]%s[/b]."
+			% GaeaNodeFloatOp.Operation.keys()[node.get_enum_selection(0)]
+			)\
+		.append_failure_message("Arguments: %s\n Expected result: %s\n Returned result: %s" % [args, expected, result])\
+		.is_equal(expected)

--- a/testing/graph_nodes/operations/num_op.gd.uid
+++ b/testing/graph_nodes/operations/num_op.gd.uid
@@ -1,0 +1,1 @@
+uid://bepf4ti2m05yt


### PR DESCRIPTION
This PR adds tests for all nodes of the operation kind (`GaeaNodeFloatOp`, `GaeaNodeIntOp`, `GaeaNodeDataOp` and `GaeaNodeDatasOp`). It also fixes a problem with the `GaeaNodeDataOp` where smoothstep wasn't working correctly and it adds the power operation to it.