### PR TITLE
Add the `ToHeight2D/3D` node, used to create side-view or 3D terrain.

### DIFF
--- a/addons/gaea/graph/graph_nodes/root/data/generation/snake_path_2d.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/generation/snake_path_2d.gd
@@ -63,7 +63,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
 	var direction_weights: Dictionary[Vector2i, float] = {
 		Vector2i.LEFT: _get_arg(&"move_left_weight", area, graph),
 		Vector2i.RIGHT: _get_arg(&"move_right_weight", area, graph),

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -1,14 +1,20 @@
 @tool
 class_name GaeaNodeToHeight
 extends GaeaNodeResource
-## Node description.
-
+## Transforms [param reference_data] into a new data grid where the height of each column is determined by [param height_offset] + ([param reference_data] * [param displacement_intensity])
+##
+## For each cell in [param reference_data]'s [param reference_y] row, it'll get the [code]float[/code] value,
+## multiply it by [param displacement_intensity] and add [param height_offset] to it. This will be
+## the column's height, and every cell below that height (inclusive) will be full while every cell above
+## will be empty.[br][br]
+## This functions to create a heightmap, which can be used to create 2D side-view or
+## 3D terrain.[br][br]
+## [b]Note: Keep in mind the y axis in Godot is negative for up in 2D and down in 3D.[/b]
 
 enum Type {
-	TYPE_2D, TYPE_3D
+	TYPE_2D, ## Referenced data will only take into account the x coordinate of the cell.
+	TYPE_3D ## Referenced data will take into account both the x and the z coordinates of the cell.
 }
-
-var type: Type
 
 
 func _get_title() -> String:
@@ -20,9 +26,9 @@ func _get_description() -> String:
 	[param height_offset] + ([param reference_data] * [param displacement_intensity]).\n"
 	match get_enum_selection(0):
 		Type.TYPE_2D:
-			desc += "\nReferences all the x values of the [param reference_y] column."
+			desc += "\nReferences all the x values of the [param reference_y] row."
 		Type.TYPE_3D:
-			desc += "\nReferences all the x,z values of the [param reference_y] column."
+			desc += "\nReferences all the x,z values of the [param reference_y] row."
 	return desc
 
 
@@ -83,7 +89,7 @@ func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Varian
 	var height_offset: int = _get_arg(&"height_offset", area, graph)
 	var displacement: int = _get_arg(&"displacement_intensity", area, graph)
 	var data: Dictionary[Vector3i, float] = {}
-	var type: Type = get_enum_selection(0)
+	var type: Type = get_enum_selection(0) as Type
 
 	for x in _get_axis_range(Vector3i.AXIS_X, area):
 		if not reference_data.has(Vector3i(x, row, 0)):

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -16,7 +16,25 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	return "Node description."
+	var desc: String =  "Transforms [param reference_data] into a new data grid where the height of each column is determined by\
+	[param height_offset] + ([param reference_data] * [param displacement_intensity]).\n"
+	match get_enum_selection(0):
+		Type.TYPE_2D:
+			desc += "\nReferences all the x values of the [param reference_y] column."
+		Type.TYPE_3D:
+			desc += "\nReferences all the x,z values of the [param reference_y] column."
+	return desc
+
+
+func _get_tree_items() -> Array[GaeaNodeResource]:
+	var items: Array[GaeaNodeResource]
+	for type in Type.values():
+		var item: GaeaNodeToHeight = get_script().new()
+		item.set_tree_name_override(_get_title() + _get_enum_option_display_name(0, type))
+		item.set_default_enum_value_override(0, type)
+		items.append(item)
+
+	return items
 
 
 func _get_enums_count() -> int:

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -1,0 +1,79 @@
+@tool
+class_name GaeaNodeToHeight
+extends GaeaNodeResource
+## Node description.
+
+
+enum Type {
+	TYPE_2D, TYPE_3D
+}
+
+var type: Type
+
+
+func _get_title() -> String:
+	return "ToHeight"
+
+
+func _get_description() -> String:
+	return "Node description."
+
+
+func _get_enums_count() -> int:
+	return 1
+
+
+func _get_enum_options(_enum_idx: int) -> Dictionary:
+	return Type
+
+
+func _get_enum_option_display_name(_enum_idx: int, option_value: int) -> String:
+	return Type.find_key(option_value).trim_prefix("TYPE_")
+
+
+
+# List of all the arguments, preferably in &"snake_case".
+func _get_arguments_list() -> Array[StringName]:
+	return [&"reference_data", &"reference_y",
+			&"height_offset", &"displacement_intensity"]
+
+
+func _get_argument_type(arg_name: StringName) -> GaeaValue.Type:
+	match arg_name:
+		&"reference_data": return GaeaValue.Type.DATA
+		_: return GaeaValue.Type.INT
+
+
+func _get_argument_default_value(arg_name: StringName) -> Variant:
+	match arg_name:
+		&"displacement_intensity": return 16
+	return super(arg_name)
+
+
+# List of all the outputs, preferably in &"snake_case"
+func _get_output_ports_list() -> Array[StringName]:
+	return [&"data"]
+
+
+func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
+	return GaeaValue.Type.DATA
+
+
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
+	var reference_data: Dictionary = _get_arg(&"reference_data", area, graph)
+	var row: int = _get_arg(&"reference_y", area, graph)
+	var height_offset: int = _get_arg(&"height_offset", area, graph)
+	var displacement: int = _get_arg(&"displacement_intensity", area, graph)
+	var data: Dictionary[Vector3i, float] = {}
+	var type: Type = get_enum_selection(0)
+
+	for x in _get_axis_range(Vector3i.AXIS_X, area):
+		if not reference_data.has(Vector3i(x, row, 0)):
+			continue
+		var z_range: Array = [0] if (type == Type.TYPE_2D) else (_get_axis_range(Vector3i.AXIS_Z, area))
+		for z in z_range:
+			var height: int = floor(reference_data[Vector3i(x, row, z)] * displacement + height_offset)
+			for y in _get_axis_range(Vector3i.AXIS_Y, area):
+				if (y >= -height and type == Type.TYPE_2D) or (y <= height and type == Type.TYPE_3D):
+					data[Vector3i(x, y, z)] = 1.0
+	return data

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -56,7 +56,6 @@ func _get_enum_option_display_name(_enum_idx: int, option_value: int) -> String:
 
 
 
-# List of all the arguments, preferably in &"snake_case".
 func _get_arguments_list() -> Array[StringName]:
 	return [&"reference_data", &"reference_y",
 			&"height_offset", &"displacement_intensity",
@@ -78,8 +77,6 @@ func _get_argument_default_value(arg_name: StringName) -> Variant:
 
 
 
-
-# List of all the outputs, preferably in &"snake_case"
 func _get_output_ports_list() -> Array[StringName]:
 	return [&"data"]
 
@@ -99,7 +96,7 @@ func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictio
 
 	var remap_offset: float = 0.0
 	if not is_zero_approx(gradient_intensity):
-		remap_offset = 64.0 / gradient_intensity
+		remap_offset = 100.0 / gradient_intensity
 
 	for x in _get_axis_range(Vector3i.AXIS_X, area):
 		if not reference_data.has(Vector3i(x, row, 0)):

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -59,19 +59,24 @@ func _get_enum_option_display_name(_enum_idx: int, option_value: int) -> String:
 # List of all the arguments, preferably in &"snake_case".
 func _get_arguments_list() -> Array[StringName]:
 	return [&"reference_data", &"reference_y",
-			&"height_offset", &"displacement_intensity"]
+			&"height_offset", &"displacement_intensity",
+			&"gradient_intensity"]
 
 
 func _get_argument_type(arg_name: StringName) -> GaeaValue.Type:
 	match arg_name:
 		&"reference_data": return GaeaValue.Type.DATA
+		&"gradient_intensity": return GaeaValue.Type.FLOAT
 		_: return GaeaValue.Type.INT
 
 
 func _get_argument_default_value(arg_name: StringName) -> Variant:
 	match arg_name:
 		&"displacement_intensity": return 16
+		&"gradient_intensity": return 1.0
 	return super(arg_name)
+
+
 
 
 # List of all the outputs, preferably in &"snake_case"
@@ -88,8 +93,13 @@ func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictio
 	var row: int = _get_arg(&"reference_y", area, graph)
 	var height_offset: int = _get_arg(&"height_offset", area, graph)
 	var displacement: int = _get_arg(&"displacement_intensity", area, graph)
+	var gradient_intensity: float = _get_arg(&"gradient_intensity", area, graph)
 	var data: Dictionary[Vector3i, float] = {}
 	var type: Type = get_enum_selection(0) as Type
+
+	var remap_offset: float = 0.0
+	if not is_zero_approx(gradient_intensity):
+		remap_offset = 64.0 / gradient_intensity
 
 	for x in _get_axis_range(Vector3i.AXIS_X, area):
 		if not reference_data.has(Vector3i(x, row, 0)):
@@ -98,6 +108,12 @@ func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictio
 		for z in z_range:
 			var height: int = floor(reference_data[Vector3i(x, row, z)] * displacement + height_offset)
 			for y in _get_axis_range(Vector3i.AXIS_Y, area):
-				if (y >= -height and type == Type.TYPE_2D) or (y <= height and type == Type.TYPE_3D):
-					data[Vector3i(x, y, z)] = 1.0
+				if y >= -height and type == Type.TYPE_2D:
+					data[Vector3i(x, y, z)] = 1.0 if is_zero_approx(remap_offset) else remap(
+						y, -height + remap_offset, -height, 0, 1.0
+					)
+				elif y <= height and type == Type.TYPE_3D:
+					data[Vector3i(x, y, z)] = 1.0 if is_zero_approx(remap_offset) else remap(
+						y, height, height - remap_offset, 1.0, 0.0
+					)
 	return data

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -83,7 +83,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
 	var reference_data: Dictionary = _get_arg(&"reference_data", area, graph)
 	var row: int = _get_arg(&"reference_y", area, graph)
 	var height_offset: int = _get_arg(&"height_offset", area, graph)

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -98,10 +98,10 @@ func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictio
 	if not is_zero_approx(gradient_intensity):
 		remap_offset = 100.0 / gradient_intensity
 
+	var z_range: Array = [0] if (type == Type.TYPE_2D) else (_get_axis_range(Vector3i.AXIS_Z, area))
 	for x in _get_axis_range(Vector3i.AXIS_X, area):
 		if not reference_data.has(Vector3i(x, row, 0)):
 			continue
-		var z_range: Array = [0] if (type == Type.TYPE_2D) else (_get_axis_range(Vector3i.AXIS_Z, area))
 		for z in z_range:
 			var height: int = floor(reference_data[Vector3i(x, row, z)] * displacement + height_offset)
 			for y in _get_axis_range(Vector3i.AXIS_Y, area):

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd.uid
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd.uid
@@ -1,0 +1,1 @@
+uid://b0xqvegteqx7c

--- a/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
+++ b/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
@@ -23,7 +23,6 @@ func test_2d() -> void:
 	node.set_enum_value(0, GaeaNodeToHeight.Type.TYPE_2D)
 	node.set_argument_value(&"height_offset", -4)
 	var generated_data: Dictionary = node._get_data(&"data", AREA, null)
-	print(generated_data)
 	assert_dict(generated_data)\
 		.override_failure_message("Empty result from [b]GaeaNodeToHeight2D[/b].")\
 		.is_not_empty()

--- a/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
+++ b/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
@@ -1,0 +1,36 @@
+extends GdUnitTestSuite
+
+
+const AREA: AABB = AABB(Vector3.ZERO, Vector3(1, 4, 1) * 16)
+const EXPECTED_HASH_2D: int = 1125934261
+const EXPECTED_HASH_3D: int = 112159610
+
+var reference_data: Dictionary = {}
+var node: GaeaNodeToHeight
+
+
+func before() -> void:
+	var noise: FastNoiseLite = FastNoiseLite.new()
+	for x in range(AREA.position.x, AREA.end.x):
+		for z in range(AREA.position.z, AREA.end.z):
+			reference_data[Vector3i(x, 0, z)] = noise.get_noise_3d(x, 0, z)
+	node = GaeaNodeToHeight.new()
+	node.set_argument_value(&"reference_data", reference_data)
+
+
+
+
+func test_2d() -> void:
+	node.set_enum_value(0, GaeaNodeToHeight.Type.TYPE_2D)
+	node.set_argument_value(&"height_offset", -4)
+	assert_int(node._get_data(&"data", AREA, null).hash())\
+		.override_failure_message("Unexpected result from [b]GaeaNodeToHeight2D[/b].")\
+		.is_equal(EXPECTED_HASH_2D)
+
+
+func test_3d() -> void:
+	node.set_enum_value(0, GaeaNodeToHeight.Type.TYPE_3D)
+	node.set_argument_value(&"height_offset", 4)
+	assert_int(node._get_data(&"data", AREA, null).hash())\
+		.override_failure_message("Unexpected result from [b]GaeaNodeToHeight3D[/b].")\
+		.is_equal(EXPECTED_HASH_3D)

--- a/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
+++ b/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
@@ -2,8 +2,8 @@ extends GdUnitTestSuite
 
 
 const AREA: AABB = AABB(Vector3.ZERO, Vector3(1, 4, 1) * 16)
-const EXPECTED_HASH_2D: int = 1603666212
-const EXPECTED_HASH_3D: int = 788074031
+const EXPECTED_HASH_2D: int = 3725516071
+const EXPECTED_HASH_3D: int = 2178371583
 
 var reference_data: Dictionary = {}
 var node: GaeaNodeToHeight
@@ -13,22 +13,34 @@ func before() -> void:
 	var noise: FastNoiseLite = FastNoiseLite.new()
 	for x in range(AREA.position.x, AREA.end.x):
 		for z in range(AREA.position.z, AREA.end.z):
-			reference_data[Vector3i(x, 0, z)] = noise.get_noise_3d(x, 0, z)
+			reference_data[Vector3i(x, 1, z)] = noise.get_noise_3d(x, 0, z)
 	node = GaeaNodeToHeight.new()
 	node.set_argument_value(&"reference_data", reference_data)
+	node.set_argument_value(&"reference_y", 1)
 
 
 func test_2d() -> void:
 	node.set_enum_value(0, GaeaNodeToHeight.Type.TYPE_2D)
 	node.set_argument_value(&"height_offset", -4)
-	assert_int(node._get_data(&"data", AREA, null).hash())\
+	var generated_data: Dictionary = node._get_data(&"data", AREA, null)
+	print(generated_data)
+	assert_dict(generated_data)\
+		.override_failure_message("Empty result from [b]GaeaNodeToHeight2D[/b].")\
+		.is_not_empty()
+	assert_int(generated_data.hash())\
 		.override_failure_message("Unexpected result from [b]GaeaNodeToHeight2D[/b].")\
+		.append_failure_message("Generated: %s\nExpected: %s" % [generated_data.hash(), EXPECTED_HASH_2D])\
 		.is_equal(EXPECTED_HASH_2D)
 
 
 func test_3d() -> void:
 	node.set_enum_value(0, GaeaNodeToHeight.Type.TYPE_3D)
 	node.set_argument_value(&"height_offset", 4)
-	assert_int(node._get_data(&"data", AREA, null).hash())\
+	var generated_data: Dictionary = node._get_data(&"data", AREA, null)
+	assert_dict(generated_data)\
+		.override_failure_message("Empty result from [b]GaeaNodeToHeight3D[/b].")\
+		.is_not_empty()
+	assert_int(generated_data.hash())\
 		.override_failure_message("Unexpected result from [b]GaeaNodeToHeight3D[/b].")\
+		.append_failure_message("Generated: %s\nExpected: %s" % [generated_data.hash(), EXPECTED_HASH_3D])\
 		.is_equal(EXPECTED_HASH_3D)

--- a/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
+++ b/testing/graph_nodes/to_height/to_height_2d_and_3d.gd
@@ -2,8 +2,8 @@ extends GdUnitTestSuite
 
 
 const AREA: AABB = AABB(Vector3.ZERO, Vector3(1, 4, 1) * 16)
-const EXPECTED_HASH_2D: int = 1125934261
-const EXPECTED_HASH_3D: int = 112159610
+const EXPECTED_HASH_2D: int = 1603666212
+const EXPECTED_HASH_3D: int = 788074031
 
 var reference_data: Dictionary = {}
 var node: GaeaNodeToHeight
@@ -16,8 +16,6 @@ func before() -> void:
 			reference_data[Vector3i(x, 0, z)] = noise.get_noise_3d(x, 0, z)
 	node = GaeaNodeToHeight.new()
 	node.set_argument_value(&"reference_data", reference_data)
-
-
 
 
 func test_2d() -> void:

--- a/testing/graph_nodes/to_height/to_height_2d_and_3d.gd.uid
+++ b/testing/graph_nodes/to_height/to_height_2d_and_3d.gd.uid
@@ -1,0 +1,1 @@
+uid://ds4py82j4mpkj


### PR DESCRIPTION
The `ToHeight` node takes a reference data and transforms it into a 'heightmap'.

| Graph | Terrain |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3577509b-8b7d-41fd-b72f-323c2da96f2b) |  ![image](https://github.com/user-attachments/assets/1f7a32bb-878a-4aa5-83ea-1f3817088af5) |
| ![image](https://github.com/user-attachments/assets/0ec83bb5-d596-4ee3-848c-b8c20271f9b7) | ![image](https://github.com/user-attachments/assets/8c55f8d9-fac9-4df9-84c4-09c6437f1bf1) | 

TO-DO:
- [x] Possibly make the values in the produced data grid a gradient that goes from 1.0 at the top to the negative values.
- [x] Add tests.
