### PR TITLE
Don't clamp gradient material sampling to 0.0-1.0

### DIFF
--- a/addons/gaea/resources/materials/distribution/gradient_material.gd
+++ b/addons/gaea/resources/materials/distribution/gradient_material.gd
@@ -68,7 +68,6 @@ func _is_sampled() -> bool:
 
 
 func _get_sampled_resource(_rng: RandomNumberGenerator, value: float) -> GaeaMaterial:
-	value = clampf(value, 0.0, 1.0)
 	for idx: int in points.size():
 		var next_point_offset: float
 		if (idx + 1) >= points.size():


### PR DESCRIPTION
This prevented users from using negative values in the gradient