### PR TITLE
Update _get_data function signatures to specify return type

### DIFF
--- a/addons/gaea/graph/graph_nodes/generic_classes/set_operation.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/set_operation.gd
@@ -83,6 +83,7 @@ func _on_enum_value_changed(_enum_idx: int, _option_value: int) -> void:
 	notify_argument_list_changed()
 
 
+# The generic Dictionary type here is expected, and the type will be updated in child classes.
 func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
 	var grids: Array[Dictionary] = []
 	for arg in _get_arguments_list():

--- a/addons/gaea/graph/graph_nodes/root/data/basic/fill.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/basic/fill.gd
@@ -28,7 +28,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var grid: Dictionary[Vector3i, float]
 	var value: float = _get_arg(&"value", area, graph)
 	for x in _get_axis_range(Vector3i.AXIS_X, area):

--- a/addons/gaea/graph/graph_nodes/root/data/border/border.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/border/border.gd
@@ -50,7 +50,7 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"data"]
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var neighbors: Array[Vector2i] = _get_arg(&"neighbors", area, graph)
 	var inside: bool = _get_arg(&"inside", area, graph)
 	var input_data: Dictionary[Vector3i, float] = _get_arg(&"data", area, graph)

--- a/addons/gaea/graph/graph_nodes/root/data/filters/filter.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/filters/filter.gd
@@ -38,11 +38,11 @@ func _is_available() -> bool:
 	return get_type() != GaeaValue.Type.NULL
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	seed(graph.generator.seed + salt)
 
-	var input_data: Dictionary = _get_arg(&"input_grid", area, graph)
-	var new_data: Dictionary = {}
+	var input_data: Dictionary[Vector3i, float] = _get_arg(&"input_grid", area, graph)
+	var new_data: Dictionary[Vector3i, float] = {}
 	for cell: Vector3i in input_data:
 		if _passes_filter(input_data, cell, area, graph):
 			new_data.set(cell, input_data.get(cell))

--- a/addons/gaea/graph/graph_nodes/root/data/generation/falloff_map.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/generation/falloff_map.gd
@@ -164,7 +164,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var start: float = _get_arg(&"start", area, graph)
 	var end: float = _get_arg(&"end", area, graph)
 	var grid: Dictionary[Vector3i, float]

--- a/addons/gaea/graph/graph_nodes/root/data/generation/floor_walker.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/generation/floor_walker.gd
@@ -96,7 +96,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var axis_type: AxisType = get_enum_selection(0) as AxisType
 
 	var _starting_position: Vector3 = _get_arg(&"starting_position", area, graph)

--- a/addons/gaea/graph/graph_nodes/root/data/generation/snake_path_2d.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/generation/snake_path_2d.gd
@@ -63,7 +63,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var direction_weights: Dictionary[Vector2i, float] = {
 		Vector2i.LEFT: _get_arg(&"move_left_weight", area, graph),
 		Vector2i.RIGHT: _get_arg(&"move_right_weight", area, graph),

--- a/addons/gaea/graph/graph_nodes/root/data/noise/noise.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/noise/noise.gd
@@ -60,7 +60,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var _noise: FastNoiseLite = FastNoiseLite.new()
 	_noise.seed = graph.generator.seed + salt
 	_noise.noise_type = get_enum_selection(0) as FastNoiseLite.NoiseType

--- a/addons/gaea/graph/graph_nodes/root/data/operations/datas/datas_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/operations/datas/datas_operation.gd
@@ -106,7 +106,7 @@ func _get_output_port_display_name(_output_name: StringName) -> String:
 
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var operation: Operation = get_enum_selection(0) as Operation
 	var a_grid: Dictionary = _get_arg(&"a", area, graph)
 	var b_grid: Dictionary = _get_arg(&"b", area, graph)

--- a/addons/gaea/graph/graph_nodes/root/data/operations/scalar/data_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/operations/scalar/data_operation.gd
@@ -56,7 +56,7 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 	return definitions
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var operation: Operation = get_enum_selection(0) as Operation
 	var operation_definition: Definition = OPERATION_DEFINITIONS[operation]
 	var args: Array

--- a/addons/gaea/graph/graph_nodes/root/data/operations/sets/data_set_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/operations/sets/data_set_operation.gd
@@ -10,3 +10,9 @@ func _get_title() -> String:
 
 func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
+
+
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
+	var data: Dictionary[Vector3i, float]
+	data.assign(super(output_port, area, graph))
+	return data

--- a/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/transformation/to_height.gd
@@ -85,7 +85,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
 	var reference_data: Dictionary = _get_arg(&"reference_data", area, graph)
 	var row: int = _get_arg(&"reference_y", area, graph)
 	var height_offset: int = _get_arg(&"height_offset", area, graph)

--- a/addons/gaea/graph/graph_nodes/root/map/mappers/basic_mapper.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/mappers/basic_mapper.gd
@@ -33,7 +33,7 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"reference_data", &"material"]
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, GaeaMaterial]:
 	var grid: Dictionary[Vector3i, GaeaMaterial] = {}
 	var grid_data := _get_arg(&"reference_data", area, graph) as Dictionary
 	var material := _get_arg(&"material", area, graph) as GaeaMaterial

--- a/addons/gaea/graph/graph_nodes/root/map/operations/map_set_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/operations/map_set_operation.gd
@@ -10,3 +10,9 @@ func _get_title() -> String:
 
 func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.MAP
+
+
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, GaeaMaterial]:
+	var data: Dictionary[Vector3i, GaeaMaterial]
+	data.assign(super(output_port, area, graph))
+	return data

--- a/addons/gaea/graph/graph_nodes/root/map/placing/random_scatter.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/placing/random_scatter.gd
@@ -36,7 +36,7 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"reference_data", &"material"]
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, GaeaMaterial]:
 	var grid_data: Dictionary = _get_arg(&"reference_data", area, graph)
 	var material: GaeaMaterial = _get_arg(&"material", area, graph)
 	var rng := define_rng(graph)

--- a/addons/gaea/graph/graph_nodes/root/map/placing/rules_placer.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/placing/rules_placer.gd
@@ -51,7 +51,7 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"reference_data", &"material"]
 
 
-func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, GaeaMaterial]:
 	var grid_data: Dictionary = _get_arg(&"reference_data", area, graph)
 	var material: GaeaMaterial = _get_arg(&"material", area, graph)
 	var rng := define_rng(graph)

--- a/addons/gaea/graph/graph_nodes/root/other/composition/compose_range.gd
+++ b/addons/gaea/graph/graph_nodes/root/other/composition/compose_range.gd
@@ -41,8 +41,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.RANGE
 
 
-
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[String, float]:
 	return {
 		"min": _get_arg(&"min", area, graph),
 		"max": _get_arg(&"max", area, graph),

--- a/addons/gaea/graph/graph_nodes/root/resources/samplers/texture_sampler.gd
+++ b/addons/gaea/graph/graph_nodes/root/resources/samplers/texture_sampler.gd
@@ -34,15 +34,15 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.DATA
 
 
-func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary:
+func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[String, float]:
 	var texture: Texture = _get_arg(&"texture", area, graph)
 	if not is_instance_valid(texture):
 		return {}
 
-	var r_grid: Dictionary
-	var g_grid: Dictionary
-	var b_grid: Dictionary
-	var alpha_grid: Dictionary
+	var r_grid: Dictionary[String, float]
+	var g_grid: Dictionary[String, float]
+	var b_grid: Dictionary[String, float]
+	var alpha_grid: Dictionary[String, float]
 
 	var slices: Array[Image] # Only one is texture is 2D
 	if texture is Texture2D:


### PR DESCRIPTION
# Update `_get_data` Function Signatures

## Summary

This PR updates the `_get_data` function signatures to explicitly specify their return types as either:

* `Dictionary[Vector3i, float]`
* `Dictionary[Vector3i, GaeaMaterial]`

Closes #409

## Notes

Some nodes still return variant type but it's expected because he could return multiples types like the vector OP node.
