### PR TITLE
Fix `.gitattributes` to include addon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
-/**        export-ignore
 /addons/gaea    !export-ignore
 /addons/gaea/** !export-ignore
+
+# Exclude everything else.
+/**        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,10 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+
+/addons    !export-ignore
+/addons/** export-ignore
+
 /addons/gaea    !export-ignore
 /addons/gaea/** !export-ignore
-
-# Exclude everything else.
-/**        export-ignore


### PR DESCRIPTION
# Fix git attributes to download addon

## Summary

Updat git attributes to ensure proper inclusion and exclusion of the addons folder for downloading

Closes #412.