### PR TITLE
Add support for TileMap pattern rendering

### DIFF
--- a/addons/gaea/nodes/renderers/tilemap_renderer.gd
+++ b/addons/gaea/nodes/renderers/tilemap_renderer.gd
@@ -15,6 +15,7 @@ func _render(grid: GaeaGrid) -> void:
 
 	for layer_idx in grid.get_layers_count():
 		var terrains: Dictionary[TileMapGaeaMaterial, Array] = {}
+		var patterns: Dictionary[TileMapGaeaMaterial, Array] = {}
 		if tile_map_layers.size() <= layer_idx or not is_instance_valid(tile_map_layers.get(layer_idx)):
 			continue
 
@@ -25,11 +26,21 @@ func _render(grid: GaeaGrid) -> void:
 					tile_map_layers[layer_idx].set_cell(Vector2i(cell.x, cell.y), value.source_id, value.atlas_coord, value.alternative_tile)
 				elif value.type == TileMapGaeaMaterial.Type.TERRAIN:
 					terrains.get_or_add(value, []).append(Vector2i(cell.x, cell.y))
+				elif value.type == TileMapGaeaMaterial.Type.PATTERN:
+					patterns.get_or_add(value, []).append(Vector2i(cell.x, cell.y))
 
-		for material: TileMapGaeaMaterial in terrains:
+		for terrain_material: TileMapGaeaMaterial in terrains:
 			tile_map_layers[layer_idx].set_cells_terrain_connect(
-				terrains.get(material), material.terrain_set, material.terrain
+				terrains.get(terrain_material), terrain_material.terrain_set, terrain_material.terrain
 			)
+
+		for pattern_material: TileMapGaeaMaterial in patterns:
+			var pattern := tile_map_layers[layer_idx].tile_set.get_pattern(pattern_material.pattern_index)
+			for cell in patterns.get(pattern_material):
+				tile_map_layers[layer_idx].set_pattern(
+					cell + pattern_material.pattern_offset,
+					pattern
+				)
 
 
 func _on_area_erased(area: AABB) -> void:

--- a/addons/gaea/resources/materials/data/tilemap_material.gd
+++ b/addons/gaea/resources/materials/data/tilemap_material.gd
@@ -5,7 +5,8 @@ extends GaeaMaterial
 
 enum Type {
 	SINGLE_CELL, ## Tile is just a single cell in the TileMap. Requires a [param source_id] and a [param atlas_coord]. Can optionally be an [param alternative_tile].
-	TERRAIN  ## Tile is a terrain from a terrain set. Allows for autotiling. Requires a [param terrain_set] and a [param terrain]
+	TERRAIN,  ## Tile is a terrain from a terrain set. Allows for autotiling. Requires a [param terrain_set] and a [param terrain]
+	PATTERN  ## Tile is a pattern of cell. Requires a [param pattern_index] and a [param pattern_offset]. 
 }
 
 ## Determines how the [TileMapGaeaRenderer] uses this material.
@@ -28,16 +29,22 @@ enum Type {
 @export var terrain_set: int = 0
 ## Terrain in the terrain set determined previously.
 @export var terrain: int = 0
+## Pattern index in the pattern list of the [TileSet].
+@export var pattern_index: int = 0
+## Pattern offset use to shift the tiles from the origin (Top left corner of the pattern).
+@export var pattern_offset: Vector2i = Vector2i.ZERO
 
 
 func _validate_property(property: Dictionary) -> void:
-	match type:
-		Type.SINGLE_CELL:
-			if property.name.begins_with("terrain"):
-				property.usage = PROPERTY_USAGE_NONE
-		Type.TERRAIN:
-			if property.name in ["source_id", "atlas_coord", "alternative_tile"]:
-				property.usage = PROPERTY_USAGE_NONE
+	if type != Type.SINGLE_CELL:
+		if property.name in ["source_id", "atlas_coord", "alternative_tile"]:
+			property.usage = PROPERTY_USAGE_NONE
+	if type != Type.TERRAIN:
+		if property.name.begins_with("terrain"):
+			property.usage = PROPERTY_USAGE_NONE
+	if type != Type.PATTERN:
+		if property.name.begins_with("pattern"):
+			property.usage = PROPERTY_USAGE_NONE
 
 
 func _is_data() -> bool:


### PR DESCRIPTION
# Add support for TileMap pattern rendering

## Summary
This PR adds support for a new `Type` in `TileMapGaeaMaterial`, enabling tiles to be rendered using TileMap **patterns** defined in the TileSet.

The Pattern material have 2 options;
- pattern_index; Pattern index in the pattern list of the [TileSet].
- pattern_offset; Pattern offset use to shift the tiles from the origin (Top left corner of the pattern).
The offset is a quick ajustement for the pattern placement because by default the patten will be placed from the top left of the pattern.

Also I placed pattern after everything because he will update multiples cell at once.

I did not update the demo scene but I tried it and works correctly

![image](https://github.com/user-attachments/assets/36c93f3b-ebfd-4b7f-a389-0a829bb2e4b8)
![image](https://github.com/user-attachments/assets/ccae8700-5194-41b0-a439-e7986da78323)
