### PR TITLE
fix export build with gaea 2.0

### DIFF
--- a/addons/gaea/editor/editor_settings.gd
+++ b/addons/gaea/editor/editor_settings.gd
@@ -25,11 +25,12 @@ const CONFIGURABLE_SLOT_COLORS := {
 	GaeaValue.Type.MAP: "map",
 }
 
-var editor_settings: EditorSettings
+var editor_settings
 
 
 func add_settings() -> void:
-	editor_settings = EditorInterface.get_editor_settings()
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	editor_settings = editor_interface.get_editor_settings()
 	_add_setting(LINE_CURVATURE, 0.5, {
 		"type": TYPE_FLOAT,
 		"hint": PROPERTY_HINT_RANGE,
@@ -84,13 +85,15 @@ func _add_setting(key: String, default_value: Variant, property_info: Dictionary
 
 
 static func get_configured_output_color() -> Color:
-	return EditorInterface.get_editor_settings().get_setting(OUTPUT_TITLE_COLOR)
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	return editor_interface.get_editor_settings().get_setting(OUTPUT_TITLE_COLOR)
 
 
 static func get_configured_color_for_value_type(value_type: GaeaValue.Type) -> Color:
 	if not CONFIGURABLE_SLOT_COLORS.has(value_type):
 		return Color.WHITE
-	var settings = EditorInterface.get_editor_settings()
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	var settings = editor_interface.get_editor_settings()
 	var setting_path = COLOR_BASE % CONFIGURABLE_SLOT_COLORS.get(value_type)
 	if settings.has_setting(setting_path):
 		return settings.get_setting(setting_path)
@@ -100,7 +103,8 @@ static func get_configured_color_for_value_type(value_type: GaeaValue.Type) -> C
 static func get_configured_icon_for_value_type(value_type: GaeaValue.Type) -> Texture:
 	if not CONFIGURABLE_SLOT_COLORS.has(value_type):
 		return preload("res://addons/gaea/assets/slots/circle.svg")
-	var settings = EditorInterface.get_editor_settings()
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	var settings = editor_interface.get_editor_settings()
 	var setting_path = ICON_BASE % CONFIGURABLE_SLOT_COLORS.get(value_type)
 	if settings.has_setting(setting_path):
 		var loaded: Object = load(settings.get_setting(setting_path))
@@ -110,16 +114,20 @@ static func get_configured_icon_for_value_type(value_type: GaeaValue.Type) -> Te
 
 
 static func get_line_curvature() -> float:
-	return EditorInterface.get_editor_settings().get_setting(LINE_CURVATURE)
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	return editor_interface.get_editor_settings().get_setting(LINE_CURVATURE)
 
 
 static func get_line_thickness() -> float:
-	return EditorInterface.get_editor_settings().get_setting(LINE_THICKNESS)
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	return editor_interface.get_editor_settings().get_setting(LINE_THICKNESS)
 
 
 static func get_minimap_opacity() -> float:
-	return EditorInterface.get_editor_settings().get_setting(MINIMAP_OPACITY)
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	return editor_interface.get_editor_settings().get_setting(MINIMAP_OPACITY)
 
 
 static func get_grid_pattern() -> int:
-	return EditorInterface.get_editor_settings().get_setting(GRID_PATTERN)
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	return editor_interface.get_editor_settings().get_setting(GRID_PATTERN)

--- a/addons/gaea/gaea.gd
+++ b/addons/gaea/gaea.gd
@@ -14,44 +14,48 @@ var _custom_project_settings: GaeaProjectSettings
 
 
 func _enter_tree() -> void:
-	_editor_selection = EditorInterface.get_selection()
-	_editor_selection.selection_changed.connect(_on_selection_changed)
+	if Engine.is_editor_hint():
+		_editor_selection = EditorInterface.get_selection()
+		_editor_selection.selection_changed.connect(_on_selection_changed)
 
-	_container = MarginContainer.new()
-	_panel = BottomPanel.instantiate()
-	_panel.plugin = self
-	_container.add_child(_panel)
-	_panel_button = add_control_to_bottom_panel(_container, "Gaea")
-	_panel_button.hide()
+		_container = MarginContainer.new()
+		_panel = BottomPanel.instantiate()
+		_panel.plugin = self
+		_container.add_child(_panel)
+		_panel_button = add_control_to_bottom_panel(_container, "Gaea")
+		_panel_button.hide()
 
-	_inspector_plugin = InspectorPlugin.new()
-	add_inspector_plugin(_inspector_plugin)
+		_inspector_plugin = InspectorPlugin.new()
+		add_inspector_plugin(_inspector_plugin)
 
-	GaeaEditorSettings.new().add_settings()
-	_custom_project_settings = GaeaProjectSettings.new()
-	_custom_project_settings.add_settings()
+		GaeaEditorSettings.new().add_settings()
+		_custom_project_settings = GaeaProjectSettings.new()
+		_custom_project_settings.add_settings()
 
 
 func _exit_tree() -> void:
-	_panel.unpopulate()
-	remove_inspector_plugin(_inspector_plugin)
-	remove_control_from_bottom_panel(_container)
-	_container.queue_free()
+	if Engine.is_editor_hint():
+		_panel.unpopulate()
+		remove_inspector_plugin(_inspector_plugin)
+		remove_control_from_bottom_panel(_container)
+		_container.queue_free()
 
 
 func _on_selection_changed() -> void:
-	var _selected: Array[Node] = _editor_selection.get_selected_nodes()
+	if Engine.is_editor_hint():
+		var _selected: Array[Node] = _editor_selection.get_selected_nodes()
 
-	if _selected.size() == 1 and _selected.front() is GaeaGenerator:
-		_panel_button.show()
-		_panel_button.set_pressed(true)
-		_panel.populate(_selected.front())
-	else:
-		if is_instance_valid(_panel.get_selected_generator()):
-			_panel_button.hide()
-			_panel_button.set_pressed(false)
-			await _panel.unpopulate()
+		if _selected.size() == 1 and _selected.front() is GaeaGenerator:
+			_panel_button.show()
+			_panel_button.set_pressed(true)
+			_panel.populate(_selected.front())
+		else:
+			if is_instance_valid(_panel.get_selected_generator()):
+				_panel_button.hide()
+				_panel_button.set_pressed(false)
+				await _panel.unpopulate()
 
 
 func _disable_plugin() -> void:
-	_custom_project_settings.remove_settings()
+	if Engine.is_editor_hint():
+		_custom_project_settings.remove_settings()

--- a/addons/gaea/graph/components/argument_editors/bitmask_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/bitmask_argument_editor.gd
@@ -6,11 +6,10 @@ class_name GaeaBitsArgumentEditor
 @onready var drop_button: TextureButton = $DropButton
 
 
-
 func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
-	await super()
+	await super ()
 	var button_group: ButtonGroup = ButtonGroup.new()
 	for button: Button in grid_container.get_children():
 		button.text = str(button.get_index() + 1)
@@ -21,7 +20,8 @@ func _configure() -> void:
 
 		button.toggled.connect(_on_value_changed.unbind(1))
 
-	drop_button.texture_normal = EditorInterface.get_base_control().get_theme_icon(&"GuiOptionArrow", &"EditorIcons")
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	drop_button.texture_normal = editor_interface.get_base_control().get_theme_icon(&"GuiOptionArrow", &"EditorIcons")
 	drop_button.toggled.connect(_on_drop_button_toggled)
 
 
@@ -37,8 +37,8 @@ func _on_value_changed() -> void:
 
 
 func get_arg_value() -> Variant:
-	if super() != null:
-		return super()
+	if super () != null:
+		return super ()
 
 	if type != GaeaValue.Type.FLAGS:
 		var num: int = 0

--- a/addons/gaea/graph/components/argument_editors/category.gd
+++ b/addons/gaea/graph/components/argument_editors/category.gd
@@ -11,18 +11,19 @@ func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
 
-	_collapse_button.texture_normal = EditorInterface.get_base_control().get_theme_icon(&"GuiTreeArrowDown", &"EditorIcons")
-	_collapse_button.texture_pressed = EditorInterface.get_base_control().get_theme_icon(&"GuiTreeArrowRight", &"EditorIcons")
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	_collapse_button.texture_normal = editor_interface.get_base_control().get_theme_icon(&"GuiTreeArrowDown", &"EditorIcons")
+	_collapse_button.texture_pressed = editor_interface.get_base_control().get_theme_icon(&"GuiTreeArrowRight", &"EditorIcons")
 	_collapse_button.visible = hint.get("collapsable", true)
 	
 
 func set_label_text(new_text: String) -> void:
-	super("[b]%s[/b]" % new_text)
+	super ("[b]%s[/b]" % new_text)
 	
 	
 func get_arg_value() -> bool:
-	if super() != null:
-		return super()
+	if super () != null:
+		return super ()
 	return _collapse_button.button_pressed
 	
 

--- a/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/parameter_name_argument_editor.gd
@@ -7,18 +7,18 @@ class_name GaeaParameterNameArgumentEditor
 @onready var _edit_button: Button = $EditButton
 
 
-
 func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
-	await super()
+	await super ()
 
-	_edit_button.icon = EditorInterface.get_base_control().get_theme_icon(&"Edit", &"EditorIcons")
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	_edit_button.icon = editor_interface.get_base_control().get_theme_icon(&"Edit", &"EditorIcons")
 
 
 func get_arg_value() -> String:
-	if super() != null:
-		return super()
+	if super () != null:
+		return super ()
 	return name_label.text
 
 
@@ -43,8 +43,9 @@ func _on_edit_button_pressed() -> void:
 
 
 func _on_line_edit_text_changed(new_text: String, line_edit: LineEdit) -> void:
+	var editor_interface = Engine.get_singleton("EditorInterface")
 	if (graph_node.generator.data.parameters.has(new_text) and new_text != name_label.text) or not new_text.is_valid_identifier():
-		line_edit.add_theme_color_override(&"font_color", EditorInterface.get_base_control().get_theme_color(&"error_color", &"Editor"))
+		line_edit.add_theme_color_override(&"font_color", editor_interface.get_base_control().get_theme_color(&"error_color", &"Editor"))
 	else:
 		line_edit.remove_theme_color_override(&"font_color")
 

--- a/addons/gaea/graph/components/argument_editors/vector_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/vector_argument_editor.gd
@@ -12,17 +12,17 @@ class_name GaeaVector3ArgumentEditor
 @onready var _z_container: HBoxContainer = $ZContainer
 
 
-
 func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
-	await super()
+	await super ()
 	_x_spin_box.value_changed.connect(argument_value_changed.emit)
 	_y_spin_box.value_changed.connect(argument_value_changed.emit)
 	_z_spin_box.value_changed.connect(argument_value_changed.emit)
-	_x_label.add_theme_color_override(&"font_color", EditorInterface.get_base_control().get_theme_color("property_color_x", "Editor"))
-	_y_label.add_theme_color_override(&"font_color", EditorInterface.get_base_control().get_theme_color("property_color_y", "Editor"))
-	_z_label.add_theme_color_override(&"font_color", EditorInterface.get_base_control().get_theme_color("property_color_z", "Editor"))
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	_x_label.add_theme_color_override(&"font_color", editor_interface.get_base_control().get_theme_color("property_color_x", "Editor"))
+	_y_label.add_theme_color_override(&"font_color", editor_interface.get_base_control().get_theme_color("property_color_y", "Editor"))
+	_z_label.add_theme_color_override(&"font_color", editor_interface.get_base_control().get_theme_color("property_color_z", "Editor"))
 
 	if type == GaeaValue.Type.VECTOR2I or type == GaeaValue.Type.VECTOR3I:
 		_x_spin_box.step = 1
@@ -64,10 +64,9 @@ func set_editor_visible(value: bool) -> void:
 		child.set_visible(value)
 
 
-
 func get_arg_value() -> Variant:
-	if super() != null:
-		return super()
+	if super () != null:
+		return super ()
 	match type:
 		GaeaValue.Type.VECTOR2:
 			return Vector2(_x_spin_box.value, _y_spin_box.value)

--- a/addons/gaea/graph/graph_nodes/node.gd
+++ b/addons/gaea/graph/graph_nodes/node.gd
@@ -27,8 +27,8 @@ var connections: Array[Dictionary]
 static var _titlebar_styleboxes: Dictionary[GaeaValue.Type, Dictionary]
 var _preview: _PreviewTexture
 var _preview_container: VBoxContainer
-var _finished_loading: bool = false : set = set_finished_loading, get = has_finished_loading
-var _finished_rebuilding: bool = true : get = has_finished_rebuilding
+var _finished_loading: bool = false: set = set_finished_loading, get = has_finished_loading
+var _finished_rebuilding: bool = true: get = has_finished_rebuilding
 var _editors: Dictionary[StringName, GaeaGraphNodeArgumentEditor]
 var _enum_editors: Array[OptionButton]
 var _last_category: GaeaArgumentCategory
@@ -43,7 +43,8 @@ func _ready() -> void:
 			var script = resource.get_script()
 			if is_instance_valid(script):
 				var documentation_button := Button.new()
-				documentation_button.icon = EditorInterface.get_editor_theme().get_icon(&"HelpSearch", &"EditorIcons")
+				var editor_interface = Engine.get_singleton("EditorInterface")
+				documentation_button.icon = editor_interface.get_editor_theme().get_icon(&"HelpSearch", &"EditorIcons")
 				documentation_button.flat = true
 				get_titlebar_hbox().add_child(documentation_button)
 				documentation_button.pressed.connect(_open_node_documentation)
@@ -396,8 +397,9 @@ func _open_node_documentation():
 	if not is_instance_valid(script):
 		return
 
-	var resource_class_name := (script as GDScript).get_global_name()
-	var script_editor := EditorInterface.get_script_editor()
+	var resource_class_name = (script as GDScript).get_global_name()
+	var editor_interface = Engine.get_singleton("EditorInterface")
+	var script_editor = editor_interface.get_script_editor()
 	script_editor.goto_help("class_name:%s" % resource_class_name)
 
 

--- a/addons/gaea/graph/graph_nodes/root/data/border/border.gd
+++ b/addons/gaea/graph/graph_nodes/root/data/border/border.gd
@@ -29,13 +29,13 @@ func _get_argument_type(arg_name: StringName) -> GaeaValue.Type:
 		&"data": return GaeaValue.Type.DATA
 		&"neighbors": return GaeaValue.Type.NEIGHBORS
 		&"inside": return GaeaValue.Type.BOOLEAN
-	return super(arg_name)
+	return super (arg_name)
 
 
 func _get_argument_default_value(arg_name: StringName) -> Variant:
 	match arg_name:
 		&"neighbors": return [Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN]
-	return super(arg_name)
+	return super (arg_name)
 
 
 func _get_output_ports_list() -> Array[StringName]:
@@ -51,7 +51,7 @@ func _get_required_arguments() -> Array[StringName]:
 
 
 func _get_data(_output_port: StringName, area: AABB, graph: GaeaGraph) -> Dictionary[Vector3i, float]:
-	var neighbors: Array[Vector2i] = _get_arg(&"neighbors", area, graph)
+	var neighbors: Array = _get_arg(&"neighbors", area, graph)
 	var inside: bool = _get_arg(&"inside", area, graph)
 	var input_data: Dictionary[Vector3i, float] = _get_arg(&"data", area, graph)
 

--- a/addons/gaea/resources/gaea_value.gd
+++ b/addons/gaea/resources/gaea_value.gd
@@ -157,7 +157,7 @@ static func get_default_color(type: Type) -> Color:
 			return Color("f0f8ff") # WHITE
 		Type.MAP:
 			return Color("27ae60") # GREEN
-		Type.TEXTURE: 
+		Type.TEXTURE:
 			return Color("e67e22") # ORANGE
 	return Color.WHITE
 
@@ -186,7 +186,8 @@ static func get_display_icon(type: Type) -> Texture2D:
 		Type.MATERIAL:
 			return load("uid://b0vqox8bodse")
 		Type.TEXTURE:
-			return EditorInterface.get_base_control().get_theme_icon(&"Image", &"EditorIcons")
+			var editor_interface = Engine.get_singleton("EditorInterface")
+			return editor_interface.get_base_control().get_theme_icon(&"Image", &"EditorIcons")
 		# Dictionary types
 		Type.DATA:
 			return load("uid://dkccxw7yq1mth")


### PR DESCRIPTION
When was build my game with Gaea 2.0 was throwing the error:
`Parse Error: Identifier "EditorInterface" not declared in the current scope when build #416`

I figure out that Godot Editor References in runtime when exported don't exists, so after i search and found this [solution](https://forum.godotengine.org/t/how-to-strip-editor-specific-code-from-build-in-godot-4-2/41978/4), was recommended to replace the EditorInterface for a get_singleton.

With this we can export game with Gaea, but we lose some autocompletes and types