### PR TITLE
Fix for Floor Walker's starting position argument value being set to a float instead of a vector3i

### DIFF
--- a/addons/gaea/graph/components/argument_editors/vector_argument_editor.gd
+++ b/addons/gaea/graph/components/argument_editors/vector_argument_editor.gd
@@ -16,9 +16,9 @@ func _configure() -> void:
 	if is_part_of_edited_scene():
 		return
 	await super ()
-	_x_spin_box.value_changed.connect(argument_value_changed.emit)
-	_y_spin_box.value_changed.connect(argument_value_changed.emit)
-	_z_spin_box.value_changed.connect(argument_value_changed.emit)
+	_x_spin_box.value_changed.connect(_on_slider_changed_value.unbind(1))
+	_y_spin_box.value_changed.connect(_on_slider_changed_value.unbind(1))
+	_z_spin_box.value_changed.connect(_on_slider_changed_value.unbind(1))
 	var editor_interface = Engine.get_singleton("EditorInterface")
 	_x_label.add_theme_color_override(&"font_color", editor_interface.get_base_control().get_theme_color("property_color_x", "Editor"))
 	_y_label.add_theme_color_override(&"font_color", editor_interface.get_base_control().get_theme_color("property_color_y", "Editor"))
@@ -51,6 +51,10 @@ func _configure() -> void:
 	_x_spin_box.allow_greater = not hint.has("max")
 	_y_spin_box.allow_greater = not hint.has("max")
 	_z_spin_box.allow_greater = not hint.has("max")
+
+
+func _on_slider_changed_value() -> void:
+	argument_value_changed.emit(get_arg_value());
 
 
 func set_editor_visible(value: bool) -> void:

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -398,9 +398,7 @@ func _get_arg(arg_name: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 			_log_error("Could not get data from previous node, using default value instead.", graph, connected_id)
 			return get_argument_default_value(arg_name)
 
-	var arg_value = arguments.get(arg_name, get_argument_default_value(arg_name))
-	_log_arg(arg_name, graph, arg_value)
-	return arg_value
+	return arguments.get(arg_name, get_argument_default_value(arg_name))
 #endregion
 
 
@@ -560,12 +558,9 @@ func _log_data(output_port: StringName, graph: GaeaGraph):
 
 
 # If enabled in [member GaeaGraph.logging], log the argument information. (See [enum GaeaGraph.Log]).
-func _log_arg(arg:String, graph: GaeaGraph, value:Variant = null):
+func _log_arg(arg:String, graph: GaeaGraph):
 	if is_instance_valid(graph) and graph.logging & GaeaGraph.Log.ARGS > 0:
-		if (value == null):
-			print("Arg       |   %s on %s" % [arg, _get_title()])
-		else:
-			print("Arg       |   %s on %s: %s" % [arg, _get_title(), value])
+		print("Arg       |   %s on %s" % [arg, _get_title()])
 
 
 ## Display a error message in the Output log panel.

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -398,7 +398,9 @@ func _get_arg(arg_name: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 			_log_error("Could not get data from previous node, using default value instead.", graph, connected_id)
 			return get_argument_default_value(arg_name)
 
-	return arguments.get(arg_name, get_argument_default_value(arg_name))
+	var arg_value = arguments.get(arg_name, get_argument_default_value(arg_name))
+	_log_arg(arg_name, graph, arg_value)
+	return arg_value
 #endregion
 
 
@@ -558,9 +560,12 @@ func _log_data(output_port: StringName, graph: GaeaGraph):
 
 
 # If enabled in [member GaeaGraph.logging], log the argument information. (See [enum GaeaGraph.Log]).
-func _log_arg(arg:String, graph: GaeaGraph):
+func _log_arg(arg:String, graph: GaeaGraph, value:Variant = null):
 	if is_instance_valid(graph) and graph.logging & GaeaGraph.Log.ARGS > 0:
-		print("Arg       |   %s on %s" % [arg, _get_title()])
+		if (value == null):
+			print("Arg       |   %s on %s" % [arg, _get_title()])
+		else:
+			print("Arg       |   %s on %s: %s" % [arg, _get_title(), value])
 
 
 ## Display a error message in the Output log panel.


### PR DESCRIPTION
Fix for #446 

**Problem**
The Variant value of FloorWalker's starting_position argument was being set to whichever of it's float values was last set.

**Solution**
The GaeaVector3ArgumentEditor was directly emitting values from the value_changed signal of it's spin boxes through the argument_changed signal. Added an intermidary _on_slider_changed_value method to properly pass the result of get_arg_value().