### PR TITLE
Make caching take in the value, not the results Dictionary

### DIFF
--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -59,7 +59,7 @@ var rng: RandomNumberGenerator
 ## Id in the [GaeaGraph] save data.
 var id: int = 0
 ## If empty, [method _get_title] will be used instead.
-var tree_name_override: String = "" : set = set_tree_name_override
+var tree_name_override: String = "": set = set_tree_name_override
 @export_storage var default_value_overrides: Dictionary[StringName, Variant]
 @export_storage var default_enum_value_overrides: Dictionary[int, int]
 
@@ -366,11 +366,6 @@ func _on_argument_value_changed(arg_name: StringName, new_value: Variant) -> voi
 	return
 
 
-
-
-
-
-
 #region Args
 ## Returns the value of the argument of [param name]. Pass in [param graph] to allow overriding with input slots.[br]
 ## [param area] is used for values of the type Data or Map. (See [enum GaeaValue.Type]).
@@ -412,7 +407,10 @@ func traverse(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 	# Caching
 	var use_caching = _use_caching(output_port, graph)
 	if use_caching and _has_cached_data(output_port, graph):
-		return _get_cached_data(output_port, graph)
+		return {
+			&"value": _get_cached_data(output_port, graph),
+			&"type": get_output_port_type(output_port)
+		}
 
 	# Validation
 	if not _has_inputs_connected(_get_required_arguments(), graph):
@@ -448,8 +446,8 @@ func _use_caching(_output_port: StringName, _graph: GaeaGraph) -> bool:
 ## Adds or sets data to the cache at GaeaNodeResource, then output_port index.
 ## This is called during [method traverse] if [method _use_caching] returns [code]true[/code],
 ## but can also be called in special cases where you want to manually add cached values.
-func _set_cached_data(output_port: StringName, graph: GaeaGraph, new_data:Dictionary) -> void:
-	var node_cache:Dictionary = graph.cache.get_or_add(self, {})
+func _set_cached_data(output_port: StringName, graph: GaeaGraph, new_data: Variant) -> void:
+	var node_cache: Dictionary = graph.cache.get_or_add(self, {})
 	node_cache[output_port] = new_data
 
 
@@ -533,7 +531,7 @@ func connection_idx_to_output(output_idx: int) -> StringName:
 
 #region Logging
 # If enabled in [member GaeaGraph.logging], log the execution information. (See [enum GaeaGraph.Log]).
-func _log_execute(message:String, area:AABB, graph: GaeaGraph):
+func _log_execute(message: String, area: AABB, graph: GaeaGraph):
 	if is_instance_valid(graph) and graph.logging & GaeaGraph.Log.EXECUTE > 0:
 		message = message.strip_edges()
 		message = message if message == "" else message + " "
@@ -541,7 +539,7 @@ func _log_execute(message:String, area:AABB, graph: GaeaGraph):
 
 
 # If enabled in [member GaeaGraph.logging], log the layer information. (See [enum GaeaGraph.Log]).
-func _log_layer(message:String, layer:int, graph: GaeaGraph):
+func _log_layer(message: String, layer: int, graph: GaeaGraph):
 	if is_instance_valid(graph) and graph.logging & GaeaGraph.Log.EXECUTE > 0:
 		message = message.strip_edges()
 		message = message if message == "" else message + " "
@@ -561,7 +559,7 @@ func _log_data(output_port: StringName, graph: GaeaGraph):
 
 
 # If enabled in [member GaeaGraph.logging], log the argument information. (See [enum GaeaGraph.Log]).
-func _log_arg(arg:String, graph: GaeaGraph):
+func _log_arg(arg: String, graph: GaeaGraph):
 	if is_instance_valid(graph) and graph.logging & GaeaGraph.Log.ARGS > 0:
 		print("Arg       |   %s on %s" % [arg, _get_title()])
 
@@ -570,7 +568,7 @@ func _log_arg(arg:String, graph: GaeaGraph):
 ## If a [param node_idx] is provided, it will display the path and position of the node.
 ## Otherwise, it will display the path of the resource.
 ## The [param node_idx] is the index of the node in the graph.resources array.
-func _log_error(message:String, graph: GaeaGraph, node_idx: int = -1):
+func _log_error(message: String, graph: GaeaGraph, node_idx: int = -1):
 	if node_idx >= 0:
 		printerr("%s:%s in node '%s' - %s" % [
 			graph.get_node(node_idx).resource_path,

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -417,7 +417,6 @@ func traverse(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 		return {}
 
 	# Get Data
-
 	_define_rng(graph)
 	_log_data(output_port, graph)
 	var results: Dictionary = {

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -411,14 +411,14 @@ func traverse(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 	# Get Data with caching
 	var data: Variant
 	var use_caching = _use_caching(output_port, graph)
-	if use_caching and has_cached_data(output_port, graph):
-		data = get_cached_data(output_port, graph)
+	if use_caching and _has_cached_data(output_port, graph):
+		data = _get_cached_data(output_port, graph)
 	else:
 		_define_rng(graph)
 		_log_data(output_port, graph)
 		data = _get_data(output_port, area, graph)
 		if use_caching:
-			set_cached_data(output_port, graph, data)
+			_set_cached_data(output_port, graph, data)
 
 	return {
 		&"value": data,
@@ -442,20 +442,20 @@ func _use_caching(_output_port: StringName, _graph: GaeaGraph) -> bool:
 ## Adds or sets data to the cache at GaeaNodeResource, then output_port index.
 ## This is called during [method traverse] if [method _use_caching] returns [code]true[/code],
 ## but can also be called in special cases where you want to manually add cached values.
-func set_cached_data(output_port: StringName, graph: GaeaGraph, new_data: Variant) -> void:
+func _set_cached_data(output_port: StringName, graph: GaeaGraph, new_data: Variant) -> void:
 	var node_cache: Dictionary = graph.cache.get_or_add(self, {})
 	node_cache[output_port] = new_data
 
 
 ## Checks if the cache has data corresponding to this node, then if it has it for output_port.
-func has_cached_data(output_port: StringName, graph: GaeaGraph) -> bool:
+func _has_cached_data(output_port: StringName, graph: GaeaGraph) -> bool:
 	return graph.cache.has(self) and graph.cache[self].has(output_port)
 
 
 ## Gets cached data by GaeaNodeResource, then output_port index.
 ## Assumes that data exists, will error out if it doesn't.
 ## See also [method has_cached_data]
-func get_cached_data(output_port: StringName, graph: GaeaGraph) -> Variant:
+func _get_cached_data(output_port: StringName, graph: GaeaGraph) -> Variant:
 	return graph.cache[self][output_port]
 #endregion
 

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -404,29 +404,26 @@ func _get_arg(arg_name: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 func traverse(output_port: StringName, area: AABB, graph: GaeaGraph) -> Variant:
 	_log_traverse(graph)
 
-	# Caching
-	var use_caching = _use_caching(output_port, graph)
-	if use_caching and _has_cached_data(output_port, graph):
-		return {
-			&"value": _get_cached_data(output_port, graph),
-			&"type": get_output_port_type(output_port)
-		}
-
 	# Validation
 	if not _has_inputs_connected(_get_required_arguments(), graph):
 		return {}
 
-	# Get Data
-	_define_rng(graph)
-	_log_data(output_port, graph)
-	var results: Dictionary = {
-		&"value": _get_data(output_port, area, graph),
+	# Get Data with caching
+	var data: Variant
+	var use_caching = _use_caching(output_port, graph)
+	if use_caching and has_cached_data(output_port, graph):
+		data = get_cached_data(output_port, graph)
+	else:
+		_define_rng(graph)
+		_log_data(output_port, graph)
+		data = _get_data(output_port, area, graph)
+		if use_caching:
+			set_cached_data(output_port, graph, data)
+
+	return {
+		&"value": data,
 		&"type": _get_output_port_type(output_port)
 	}
-
-	if use_caching:
-		_set_cached_data(output_port, graph, results)
-	return results
 
 
 ## Returns the data corresponding to [param output_port]. Should be overridden to create custom
@@ -445,19 +442,20 @@ func _use_caching(_output_port: StringName, _graph: GaeaGraph) -> bool:
 ## Adds or sets data to the cache at GaeaNodeResource, then output_port index.
 ## This is called during [method traverse] if [method _use_caching] returns [code]true[/code],
 ## but can also be called in special cases where you want to manually add cached values.
-func _set_cached_data(output_port: StringName, graph: GaeaGraph, new_data: Variant) -> void:
+func set_cached_data(output_port: StringName, graph: GaeaGraph, new_data: Variant) -> void:
 	var node_cache: Dictionary = graph.cache.get_or_add(self, {})
 	node_cache[output_port] = new_data
 
 
-# Checks if the cache has data corresponding to this node, then if it has it for output_port.
-func _has_cached_data(output_port: StringName, graph: GaeaGraph) -> bool:
+## Checks if the cache has data corresponding to this node, then if it has it for output_port.
+func has_cached_data(output_port: StringName, graph: GaeaGraph) -> bool:
 	return graph.cache.has(self) and graph.cache[self].has(output_port)
 
 
-# Gets cached data by GaeaNodeResource, then output_port index.
-# Assumes that data exists, will error out if it doesn't.
-func _get_cached_data(output_port: StringName, graph: GaeaGraph) -> Dictionary:
+## Gets cached data by GaeaNodeResource, then output_port index.
+## Assumes that data exists, will error out if it doesn't.
+## See also [method has_cached_data]
+func get_cached_data(output_port: StringName, graph: GaeaGraph) -> Variant:
 	return graph.cache[self][output_port]
 #endregion
 

--- a/addons/gaea/graph/graph_nodes/root/resources/samplers/texture_sampler.gd
+++ b/addons/gaea/graph/graph_nodes/root/resources/samplers/texture_sampler.gd
@@ -72,9 +72,9 @@ func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Diction
 				b_grid.set(cell, pixel.b)
 				alpha_grid.set(cell, pixel.a)
 
-	_set_cached_data(&"r", graph, r_grid)
-	_set_cached_data(&"g", graph, g_grid)
-	_set_cached_data(&"b", graph, b_grid)
-	_set_cached_data(&"a", graph, alpha_grid)
+	set_cached_data(&"r", graph, r_grid)
+	set_cached_data(&"g", graph, g_grid)
+	set_cached_data(&"b", graph, b_grid)
+	set_cached_data(&"a", graph, alpha_grid)
 
-	return _get_cached_data(output_port, graph)
+	return get_cached_data(output_port, graph)

--- a/addons/gaea/graph/graph_nodes/root/resources/samplers/texture_sampler.gd
+++ b/addons/gaea/graph/graph_nodes/root/resources/samplers/texture_sampler.gd
@@ -42,7 +42,7 @@ func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Diction
 	var r_grid: Dictionary[Vector3i, float]
 	var g_grid: Dictionary[Vector3i, float]
 	var b_grid: Dictionary[Vector3i, float]
-	var alpha_grid: Dictionary[Vector3i, float]
+	var a_grid: Dictionary[Vector3i, float]
 
 	var slices: Array[Image] # Only one is texture is 2D
 	if texture is Texture2D:
@@ -70,11 +70,11 @@ func _get_data(output_port: StringName, area: AABB, graph: GaeaGraph) -> Diction
 				r_grid.set(cell, pixel.r)
 				g_grid.set(cell, pixel.g)
 				b_grid.set(cell, pixel.b)
-				alpha_grid.set(cell, pixel.a)
+				a_grid.set(cell, pixel.a)
 
-	set_cached_data(&"r", graph, r_grid)
-	set_cached_data(&"g", graph, g_grid)
-	set_cached_data(&"b", graph, b_grid)
-	set_cached_data(&"a", graph, alpha_grid)
+	_set_cached_data(&"r", graph, r_grid)
+	_set_cached_data(&"g", graph, g_grid)
+	_set_cached_data(&"b", graph, b_grid)
+	_set_cached_data(&"a", graph, a_grid)
 
-	return get_cached_data(output_port, graph)
+	return _get_cached_data(output_port, graph)

--- a/addons/gaea/resources/gaea_graph.gd
+++ b/addons/gaea/resources/gaea_graph.gd
@@ -65,8 +65,8 @@ var other: Dictionary
 
 ## The currently related generator.
 var generator: GaeaGenerator
-## Cache used during generation to avoid calculating data more than once when unnecessary.
-## The inner dictionary keys is the slot output_port name and the value the cached data.
+## Cache used during generation to avoid recalculating data unnecessarily.
+## The inner dictionary keys are the slot output port names, and the values are the cached data.
 var cache: Dictionary[GaeaNodeResource, Dictionary] = {}
 
 

--- a/addons/gaea/resources/gaea_graph.gd
+++ b/addons/gaea/resources/gaea_graph.gd
@@ -66,6 +66,7 @@ var other: Dictionary
 ## The currently related generator.
 var generator: GaeaGenerator
 ## Cache used during generation to avoid calculating data more than once when unnecessary.
+## The inner dictionary keys is the slot output_port name and the value the cached data.
 var cache: Dictionary[GaeaNodeResource, Dictionary] = {}
 
 


### PR DESCRIPTION
When loading data from the cache you still need to return the dictionary with value and type properties.

Fix #432