### PR TITLE
Add copy/pasting of nodes to/from clipboard in JSON

### DIFF
--- a/addons/gaea/editor/graph_editor/graph_edit.gd
+++ b/addons/gaea/editor/graph_editor/graph_edit.gd
@@ -690,10 +690,6 @@ func _copy_nodes(data: GaeaNodesCopy) -> void:
 
 
 func _paste_nodes(at_position: Vector2, data: GaeaNodesCopy = copy_buffer) -> void:
-	var serialized: String = data.serialize()
-	data = GaeaNodesCopy.deserialize(serialized)
-
-
 	for node in get_selected():
 		node.selected = false
 

--- a/addons/gaea/editor/graph_editor/graph_edit.gd
+++ b/addons/gaea/editor/graph_editor/graph_edit.gd
@@ -690,8 +690,8 @@ func _copy_nodes(data: GaeaNodesCopy) -> void:
 
 
 func _paste_nodes(at_position: Vector2, data: GaeaNodesCopy = copy_buffer) -> void:
-	var serialized: String = Marshalls.raw_to_base64(data.serialize())
-	data = GaeaNodesCopy.deserialize(Marshalls.base64_to_raw(serialized))
+	var serialized: String = data.serialize()
+	data = GaeaNodesCopy.deserialize(serialized)
 
 
 	for node in get_selected():
@@ -827,12 +827,11 @@ func _on_main_editor_visibility_changed() -> void:
 
 func _on_copy_from_clipboard_request() -> void:
 	var copy_data: GaeaNodesCopy = _get_copy_data(get_selected())
-	DisplayServer.clipboard_set(Marshalls.raw_to_base64(copy_data.serialize()))
+	DisplayServer.clipboard_set(copy_data.serialize())
 
 
 func _on_paste_from_clipboard_request() -> void:
-	var decoded: PackedByteArray = Marshalls.base64_to_raw(DisplayServer.clipboard_get())
-	var copy_data: Variant = GaeaNodesCopy.deserialize(decoded)
+	var copy_data: Variant = GaeaNodesCopy.deserialize(DisplayServer.clipboard_get())
 	if copy_data is GaeaNodesCopy:
 		_paste_nodes(local_to_grid(get_local_mouse_position()), copy_data)
 	elif copy_data is String:

--- a/addons/gaea/editor/graph_editor/graph_edit.gd
+++ b/addons/gaea/editor/graph_editor/graph_edit.gd
@@ -2,6 +2,9 @@
 class_name GaeaGraphEdit
 extends GraphEdit
 
+signal copy_to_clipboard_request()
+signal paste_from_clipboard_request()
+
 @export var main_editor: GaeaMainEditor
 @export var bottom_note_label: RichTextLabel
 
@@ -52,6 +55,9 @@ func _ready() -> void:
 	add_theme_color_override(&"connection_rim_color", Color("141414"))
 	EditorInterface.get_script_editor().editor_script_changed.connect(_on_editor_script_changed)
 	_add_toolbar_buttons()
+
+	copy_to_clipboard_request.connect(_on_copy_from_clipboard_request)
+	paste_from_clipboard_request.connect(_on_paste_from_clipboard_request)
 
 
 #region Saving and Loading
@@ -315,10 +321,12 @@ func delete_nodes(nodes: Array[StringName]) -> void:
 	update_connections()
 
 
-func get_selected() -> Array[Node]:
-	return get_children().filter(
-		func(child: Node) -> bool: return child is GraphElement and child.selected
-	)
+func get_selected() -> Array[GraphElement]:
+	var selected: Array[GraphElement] = []
+	for child: Node in get_children():
+		if child is GraphElement and child.selected:
+			selected.append(child)
+	return selected
 
 
 func get_selected_names() -> Array[StringName]:
@@ -682,6 +690,10 @@ func _copy_nodes(data: GaeaNodesCopy) -> void:
 
 
 func _paste_nodes(at_position: Vector2, data: GaeaNodesCopy = copy_buffer) -> void:
+	var serialized: String = Marshalls.raw_to_base64(data.serialize())
+	data = GaeaNodesCopy.deserialize(Marshalls.base64_to_raw(serialized))
+
+
 	for node in get_selected():
 		node.selected = false
 
@@ -694,7 +706,7 @@ func _paste_nodes(at_position: Vector2, data: GaeaNodesCopy = copy_buffer) -> vo
 	_load_connections.call_deferred(new_connections)
 
 
-func _get_copy_data(nodes: Array) -> GaeaNodesCopy:
+func _get_copy_data(nodes: Array[GraphElement]) -> GaeaNodesCopy:
 	var copy_data: GaeaNodesCopy = GaeaNodesCopy.new()
 	for selected in nodes:
 		if selected is GaeaGraphNode:
@@ -759,10 +771,7 @@ func _on_gui_input(event: InputEvent) -> void:
 				return
 
 			var selected: Array = get_selected()
-			if selected.is_empty() and not is_instance_valid(main_editor.graph_edit.copy_buffer):
-				main_editor.popup_create_node_request.emit()
-			else:
-				main_editor.popup_node_context_menu_at_mouse_request.emit(selected)
+			main_editor.popup_node_context_menu_at_mouse_request.emit(selected)
 
 
 func _on_scroll_offset_changed(offset: Vector2) -> void:
@@ -814,3 +823,17 @@ func _on_main_editor_visibility_changed() -> void:
 	set_connection_lines_thickness(GaeaEditorSettings.get_line_thickness())
 	set_minimap_opacity(GaeaEditorSettings.get_minimap_opacity())
 #endregion
+
+
+func _on_copy_from_clipboard_request() -> void:
+	var copy_data: GaeaNodesCopy = _get_copy_data(get_selected())
+	DisplayServer.clipboard_set(Marshalls.raw_to_base64(copy_data.serialize()))
+
+
+func _on_paste_from_clipboard_request() -> void:
+	var decoded: PackedByteArray = Marshalls.base64_to_raw(DisplayServer.clipboard_get())
+	var copy_data: Variant = GaeaNodesCopy.deserialize(decoded)
+	if copy_data is GaeaNodesCopy:
+		_paste_nodes(local_to_grid(get_local_mouse_position()), copy_data)
+	elif copy_data is String:
+		EditorInterface.get_editor_toaster().push_toast(copy_data, EditorToaster.SEVERITY_ERROR)

--- a/addons/gaea/editor/graph_editor/graph_edit.gd
+++ b/addons/gaea/editor/graph_editor/graph_edit.gd
@@ -767,7 +767,10 @@ func _on_gui_input(event: InputEvent) -> void:
 				return
 
 			var selected: Array = get_selected()
-			main_editor.popup_node_context_menu_at_mouse_request.emit(selected)
+			if selected.is_empty() and not is_instance_valid(main_editor.graph_edit.copy_buffer):
+				main_editor.popup_create_node_request.emit()
+			else:
+				main_editor.popup_node_context_menu_at_mouse_request.emit(selected)
 
 
 func _on_scroll_offset_changed(offset: Vector2) -> void:

--- a/addons/gaea/editor/graph_editor/node_context_menu.gd
+++ b/addons/gaea/editor/graph_editor/node_context_menu.gd
@@ -43,7 +43,7 @@ func populate(selected: Array) -> void:
 	add_item("Clear Copy Buffer", Action.CLEAR_BUFFER)
 
 	add_separator()
-	add_item("Copy to clipboard", Action.COPY_TO_CLIPBOARD)
+	add_item("Copy to Clipboard", Action.COPY_TO_CLIPBOARD)
 	add_item("Paste from Clipboard", Action.PASTE_FROM_CLIPBOARD)
 
 	if not is_instance_valid(graph_edit.copy_buffer):

--- a/addons/gaea/editor/graph_editor/node_context_menu.gd
+++ b/addons/gaea/editor/graph_editor/node_context_menu.gd
@@ -44,7 +44,7 @@ func populate(selected: Array) -> void:
 
 	add_separator()
 	add_item("Copy to clipboard", Action.COPY_TO_CLIPBOARD)
-	add_item("Paste from clipboard", Action.PASTE_FROM_CLIPBOARD)
+	add_item("Paste from Clipboard", Action.PASTE_FROM_CLIPBOARD)
 
 	if not is_instance_valid(graph_edit.copy_buffer):
 		set_item_disabled(get_item_index(Action.PASTE), true)

--- a/addons/gaea/editor/graph_editor/node_context_menu.gd
+++ b/addons/gaea/editor/graph_editor/node_context_menu.gd
@@ -16,7 +16,9 @@ enum Action {
 	GROUP_IN_FRAME,
 	DETACH,
 	ENABLE_AUTO_SHRINK,
-	OPEN_IN_INSPECTOR
+	OPEN_IN_INSPECTOR,
+	COPY_TO_CLIPBOARD,
+	PASTE_FROM_CLIPBOARD,
 }
 
 @export var main_editor: GaeaMainEditor
@@ -40,9 +42,14 @@ func populate(selected: Array) -> void:
 	add_item("Delete", Action.DELETE)
 	add_item("Clear Copy Buffer", Action.CLEAR_BUFFER)
 
+	add_separator()
+	add_item("Copy to clipboard", Action.COPY_TO_CLIPBOARD)
+	add_item("Paste from clipboard", Action.PASTE_FROM_CLIPBOARD)
+
 	if not is_instance_valid(graph_edit.copy_buffer):
 		set_item_disabled(get_item_index(Action.PASTE), true)
 		set_item_disabled(get_item_index(Action.CLEAR_BUFFER), true)
+
 	if not selected.is_empty():
 		add_separator()
 		add_item("Group in New Frame", Action.GROUP_IN_FRAME)
@@ -57,6 +64,7 @@ func populate(selected: Array) -> void:
 		set_item_disabled(get_item_index(Action.COPY), true)
 		set_item_disabled(get_item_index(Action.CUT), true)
 		set_item_disabled(get_item_index(Action.DELETE), true)
+		set_item_disabled(get_item_index(Action.COPY_TO_CLIPBOARD), true)
 		return
 
 	if selected.front() is GaeaGraphFrame and selected.size() == 1:
@@ -128,7 +136,10 @@ func _on_id_pressed(id: int) -> void:
 		Action.GROUP_IN_FRAME:
 			var selected: Array[StringName] = graph_edit.get_selected_names()
 			_group_nodes_in_frame(selected)
-
+		Action.COPY_TO_CLIPBOARD:
+			graph_edit.copy_to_clipboard_request.emit()
+		Action.PASTE_FROM_CLIPBOARD:
+			graph_edit.paste_from_clipboard_request.emit()
 		Action.DETACH:
 			var selected: Array = graph_edit.get_selected()
 			for node: GraphElement in selected:

--- a/addons/gaea/resources/gaea_nodes_copy.gd
+++ b/addons/gaea/resources/gaea_nodes_copy.gd
@@ -8,6 +8,10 @@ var _connections: Array[Dictionary] : get = get_connections
 var _origin: Vector2 = Vector2(INF, INF) : get = get_origin
 
 
+func _init(origin = Vector2(INF, INF)) -> void:
+	_origin = origin
+
+
 func get_nodes_info() -> Dictionary[int, Dictionary]:
 	return _nodes
 
@@ -44,7 +48,13 @@ func add_frame(current_id: int, position: Vector2, data: Dictionary) -> void:
 
 
 func add_connections(connections: Array[Dictionary]) -> void:
-	_connections.append_array(connections)
+	for connection in connections:
+		add_connection(connection)
+
+
+func add_connection(connection: Dictionary) -> void:
+	if not _connections.has(connection):
+		_connections.append(connection)
 
 
 func get_node_type(id: int) -> GaeaGraph.NodeType:
@@ -61,3 +71,86 @@ func get_node_data(id: int) -> Dictionary:
 
 func get_node_position(id: int) -> Vector2:
 	return _nodes.get(id, {}).get(&"position", get_origin())
+
+
+func serialize() -> PackedByteArray:
+	var nodes_data: Dictionary[int, Array] = {}
+	var connections: PackedInt32Array = PackedInt32Array([])
+
+	for node_id: int in _nodes.keys():
+		var node_properties: Dictionary = _nodes.get(node_id, {})
+		nodes_data.set(node_id, [
+			node_properties.get(&"type"),
+			node_properties.get(&"data"),
+		])
+
+	for connection in _connections:
+		if nodes_data.has(connection.from_node) and nodes_data.has(connection.to_node):
+			connections.append_array([
+				connection.get("from_node"),
+				connection.get("from_port"),
+				connection.get("to_node"),
+				connection.get("to_port"),
+			])
+
+	var uncompressed: PackedByteArray = var_to_bytes([_origin, nodes_data, connections])
+	var compressed: PackedByteArray = PackedByteArray("GAEAvssc".to_utf8_buffer())
+	compressed.encode_u8(4, 1) # Compressed version
+	compressed.encode_u16(5, uncompressed.size())
+	compressed.encode_u8(7, FileAccess.CompressionMode.COMPRESSION_DEFLATE)
+	compressed.append_array(uncompressed.compress(FileAccess.CompressionMode.COMPRESSION_DEFLATE))
+
+	return compressed
+
+
+## Deserialize a previously serialized GaeaNodesCopy,
+## return a GaeaNodesCopy object or a string as error message.
+static func deserialize(serialized: PackedByteArray) -> Variant:
+	if serialized.slice(0, 4).get_string_from_utf8() != "GAEA":
+		return "Invalid data provided: the GAEA prefix is missing."
+
+	var version = serialized.decode_u8(4)
+	if version != 1:
+		return "Invalid data provided: the version %d is unknown." % version
+
+	var uncompressed_size: int = serialized.decode_u16(5)
+	var compression_mode: int = serialized.decode_u8(7)
+	var uncompressed: PackedByteArray = serialized.slice(8, serialized.size()).decompress(uncompressed_size, compression_mode)
+	var data = bytes_to_var(uncompressed)
+
+	if data.size() != 3 or not data[0] is Vector2 or not data[1] is Dictionary or not data[2] is PackedInt32Array:
+		return "Invalid data provided: the data could not be parsed"
+
+	var origin: Vector2 = data[0]
+	var deserialized: GaeaNodesCopy = GaeaNodesCopy.new(origin)
+
+	var nodes_data: Dictionary = data[1]
+	for node_id in nodes_data.keys():
+		var node_data = nodes_data.get(node_id)
+		if typeof(node_id) != TYPE_INT or typeof(node_data) != TYPE_ARRAY or not node_data[1] is Dictionary:
+			return "Invalid data provided: the data could not be parsed"
+		match node_data[0]:
+			GaeaGraph.NodeType.NODE:
+				var uid: String = node_data[1].get(&"uid")
+				var resource: GaeaNodeResource
+				if GaeaNodeResource.is_valid_node_resource(uid).is_empty():
+					resource = load(uid).new()
+				else:
+					resource = GaeaNodeInvalidScript.new()
+				resource.load_save_data(node_data[1])
+				deserialized.add_node(node_id, resource, node_data[1].get(&"position", origin), node_data[1])
+			GaeaGraph.NodeType.FRAME:
+				deserialized.add_frame(node_id, node_data[1].get(&"position", origin), node_data[1])
+			_:
+				return "Invalid data provided: the data could not be parsed"
+
+	var connections: PackedInt32Array = data[2]
+	@warning_ignore("integer_division")
+	for connection_id in range(0, connections.size() / 4):
+		deserialized.add_connection({
+			"from_node": connections[connection_id * 4],
+			"from_port": connections[connection_id * 4 + 1],
+			"to_node": connections[connection_id * 4 + 2],
+			"to_port": connections[connection_id * 4 + 3]
+		})
+	return deserialized

--- a/addons/gaea/resources/gaea_nodes_copy.gd
+++ b/addons/gaea/resources/gaea_nodes_copy.gd
@@ -73,9 +73,9 @@ func get_node_position(id: int) -> Vector2:
 	return _nodes.get(id, {}).get(&"position", get_origin())
 
 
-func serialize() -> PackedByteArray:
+func serialize() -> String:
 	var nodes_data: Dictionary[int, Array] = {}
-	var connections: PackedInt32Array = PackedInt32Array([])
+	var connections: Array[String] = []
 
 	for node_id: int in _nodes.keys():
 		var node_properties: Dictionary = _nodes.get(node_id, {})
@@ -86,45 +86,37 @@ func serialize() -> PackedByteArray:
 
 	for connection in _connections:
 		if nodes_data.has(connection.from_node) and nodes_data.has(connection.to_node):
-			connections.append_array([
+			connections.append("%s-%s-%s-%s" % [
 				connection.get("from_node"),
 				connection.get("from_port"),
 				connection.get("to_node"),
 				connection.get("to_port"),
 			])
 
-	var uncompressed: PackedByteArray = var_to_bytes([_origin, nodes_data, connections])
-	var compressed: PackedByteArray = PackedByteArray("GAEAvssc".to_utf8_buffer())
-	compressed.encode_u8(4, 1) # Compressed version
-	compressed.encode_u16(5, uncompressed.size())
-	compressed.encode_u8(7, FileAccess.CompressionMode.COMPRESSION_DEFLATE)
-	compressed.append_array(uncompressed.compress(FileAccess.CompressionMode.COMPRESSION_DEFLATE))
-
-	return compressed
+	return JSON.stringify({
+		"origin": _origin,
+		"nodes": nodes_data,
+		"connections": connections
+	}, "", false)
 
 
 ## Deserialize a previously serialized GaeaNodesCopy,
 ## return a GaeaNodesCopy object or a string as error message.
-static func deserialize(serialized: PackedByteArray) -> Variant:
-	if serialized.slice(0, 4).get_string_from_utf8() != "GAEA":
-		return "Invalid data provided: the GAEA prefix is missing."
+static func deserialize(serialized: String) -> Variant:
+	var data = JSON.parse_string(serialized)
 
-	var version = serialized.decode_u8(4)
-	if version != 1:
-		return "Invalid data provided: the version %d is unknown." % version
-
-	var uncompressed_size: int = serialized.decode_u16(5)
-	var compression_mode: int = serialized.decode_u8(7)
-	var uncompressed: PackedByteArray = serialized.slice(8, serialized.size()).decompress(uncompressed_size, compression_mode)
-	var data = bytes_to_var(uncompressed)
-
-	if data.size() != 3 or not data[0] is Vector2 or not data[1] is Dictionary or not data[2] is PackedInt32Array:
+	if (
+		not data is Dictionary
+		or not data.get("origin") is Vector2
+		or not data.get("nodes") is Dictionary
+		or not data.get("connections") is Array
+	):
 		return "Invalid data provided: the data could not be parsed"
 
 	var origin: Vector2 = data[0]
 	var deserialized: GaeaNodesCopy = GaeaNodesCopy.new(origin)
 
-	var nodes_data: Dictionary = data[1]
+	var nodes_data: Dictionary = data.get("nodes")
 	for node_id in nodes_data.keys():
 		var node_data = nodes_data.get(node_id)
 		if typeof(node_id) != TYPE_INT or typeof(node_data) != TYPE_ARRAY or not node_data[1] is Dictionary:
@@ -144,13 +136,14 @@ static func deserialize(serialized: PackedByteArray) -> Variant:
 			_:
 				return "Invalid data provided: the data could not be parsed"
 
-	var connections: PackedInt32Array = data[2]
+	var connections: Array = nodes_data.get("connections")
 	@warning_ignore("integer_division")
-	for connection_id in range(0, connections.size() / 4):
+	for connection_string: String in connections:
+		var split_string := connection_string.split("-")
 		deserialized.add_connection({
-			"from_node": connections[connection_id * 4],
-			"from_port": connections[connection_id * 4 + 1],
-			"to_node": connections[connection_id * 4 + 2],
-			"to_port": connections[connection_id * 4 + 3]
+			"from_node": int(split_string[0]),
+			"from_port": int(split_string[1]),
+			"to_node": int(split_string[2]),
+			"to_port": int(split_string[3])
 		})
 	return deserialized


### PR DESCRIPTION
This PR add the ability to copy/paste nodes to string that can be shared on discord or other media.
It's based on the idea of [Factorio blueprints](https://wiki.factorio.com/Blueprint_string_format).
You just select node and click Copy to clipboard
<img width="449" height="411" alt="image" src="https://github.com/user-attachments/assets/0b8a9773-9a5e-4dde-a6d8-3c084d595722" />
And you will get a string in the clipboard like this :
```json
{"origin":"(740.0, 80.0)","nodes":{"6":[0,{"arguments":{"material":null,"reference_data":{},"rules":{"(0, -1, 0)":false,"(0, 0, 0)":true}},"position":"(740.0, 80.0)","salt":581472843,"type":0,"uid":"uid://br8gcsyc04ksj"}]},"connections":[]}
```
Then when you can paste nodes from the clipboard like usual node pasting.

I also had to remove the add node popup by default on the right click for 2 reasons;
- I need to be able to always have the context menu to past from clipboard
- It's annoying to have different beavior if you have a node selected or not or an empty copy buffer

Like currently copy/paste node, the material resource is not copied but I guess we can change that in the future