### PR TITLE
Add `graph` property to GaeaNodeResource and remove the old reference passed around

### DIFF
--- a/addons/gaea/graph/components/preview_texture.gd
+++ b/addons/gaea/graph/components/preview_texture.gd
@@ -87,11 +87,7 @@ func update() -> void:
 	generation_settings.seed = graph.preview_seed
 
 	var pouch: GaeaGenerationPouch = GaeaGenerationPouch.new(generation_settings, AABB(Vector3.ZERO, sim_size))
-	var data: GaeaValue.GridType = node.resource.traverse(
-		selected_output,
-		node.graph_edit.graph,
-		pouch
-	).get("value")
+	var data: GaeaValue.GridType = node.resource.traverse(selected_output, pouch).get("value")
 	pouch.clear_all_cache()
 
 

--- a/addons/gaea/graph/graph_nodes/generic_classes/constant.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/constant.gd
@@ -31,5 +31,5 @@ func _get_overridden_output_port_idx(_output_name: StringName) -> int:
 	return 0
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
-	return _get_arg(&"value", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
+	return _get_arg(&"value", pouch)

--- a/addons/gaea/graph/graph_nodes/generic_classes/number_operation.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/number_operation.gd
@@ -130,11 +130,11 @@ func _get_output_port_display_name(_output_name: StringName) -> String:
 	return operation_definitions[get_enum_selection(0)].output
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 	var operation: Operation = get_enum_selection(0) as Operation
 	var args: Array
 	for arg_name: StringName in operation_definitions[operation].args:
-		args.append(_get_arg(arg_name, graph, pouch))
+		args.append(_get_arg(arg_name, pouch))
 	return _get_new_value(operation, args)
 
 

--- a/addons/gaea/graph/graph_nodes/generic_classes/parameter.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/parameter.gd
@@ -19,7 +19,7 @@ var hint_string: String:
 	get = _get_property_hint_string
 
 
-func _on_added_to_graph(graph: GaeaGraph) -> void:
+func _on_added_to_graph() -> void:
 	var name := _get_available_name(graph.get_node_argument(id, &"name", _get_title()))
 	graph.set_node_argument(
 		id, &"name", name
@@ -35,7 +35,7 @@ func _on_added_to_graph(graph: GaeaGraph) -> void:
 	})
 
 
-func _on_removed_from_graph(graph: GaeaGraph) -> void:
+func _on_removed_from_graph() -> void:
 	graph.remove_parameter(graph.get_node_argument(id, &"name"))
 	graph.notify_property_list_changed()
 
@@ -69,10 +69,6 @@ func _get_argument_default_value(_arg_name: StringName) -> Variant:
 
 
 func _get_available_name(from: String) -> String:
-	if not is_instance_valid(node) or not node is GaeaGraphNode:
-		return from
-	var graph: GaeaGraph = (node as GaeaGraphNode).graph_edit.graph
-
 	from = from.rstrip("1234567890")
 	var available_name: String = from
 	var suffix: int = 1
@@ -96,8 +92,8 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	)
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
-	return graph.get_parameter(_get_arg(&"name", graph, pouch))
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
+	return graph.get_parameter(_get_arg(&"name", pouch))
 
 
 func _is_available() -> bool:

--- a/addons/gaea/graph/graph_nodes/generic_classes/set_operation.gd
+++ b/addons/gaea/graph/graph_nodes/generic_classes/set_operation.gd
@@ -90,10 +90,10 @@ func _on_enum_value_changed(_enum_idx: int, _option_value: int) -> void:
 
 
 # The generic Dictionary type here is expected, and the type will be updated in child classes.
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.GridType:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.GridType:
 	var grids: Array[GaeaValue.GridType] = []
 	for arg in _get_arguments_list():
-		var arg_grid: GaeaValue.GridType = _get_arg(arg, graph, pouch)
+		var arg_grid: GaeaValue.GridType = _get_arg(arg, pouch)
 		if not arg_grid.is_empty():
 			grids.append(arg_grid)
 

--- a/addons/gaea/graph/graph_nodes/root/input/input.gd
+++ b/addons/gaea/graph/graph_nodes/root/input/input.gd
@@ -80,7 +80,7 @@ func _get_type_of_input(input: InputVar) -> GaeaValue.Type:
 			return GaeaValue.Type.NULL
 
 
-func _get_data(_output_port: StringName, _graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 	match get_enum_selection(0):
 		InputVar.WORLD_SIZE:
 			return pouch.settings.world_size

--- a/addons/gaea/graph/graph_nodes/root/map/mappers/mapper.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/mappers/mapper.gd
@@ -25,32 +25,32 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"reference", &"material"]
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Map:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Map:
 	var result: GaeaValue.Map = GaeaValue.Map.new()
-	var reference_sample: GaeaValue.Sample = _get_arg(&"reference", graph, pouch)
-	var material := _get_arg(&"material", graph, pouch) as GaeaMaterial
+	var reference_sample: GaeaValue.Sample = _get_arg(&"reference", pouch)
+	var material := _get_arg(&"material", pouch) as GaeaMaterial
 
 	if not is_instance_valid(material):
-		_log_error("Invalid material provided", graph, graph.resources.find(self))
+		_log_error("Invalid material provided", graph.resources.find(self))
 		return result
 
 	var rng: RandomNumberGenerator = _get_rng(pouch)
 
 	material = material.prepare_sample(rng)
 	if not is_instance_valid(material):
-		material = _get_arg(&"material", graph, pouch)
+		material = _get_arg(&"material", pouch)
 		var error := (
 			"Recursive limit reached (%d): Invalid material provided at %s"
 			% [GaeaMaterial.RECURSIVE_LIMIT, material.resource_path]
 		)
-		_log_error(error, graph, graph.resources.find(self))
+		_log_error(error, graph.resources.find(self))
 		return result
 
 	var args: Dictionary[StringName, Variant]
 	for arg in get_arguments_list():
 		if arg == &"reference" or arg == &"material":
 			continue
-		args.set(arg, _get_arg(arg, graph, pouch))
+		args.set(arg, _get_arg(arg, pouch))
 
 	for cell in reference_sample.get_cells():
 		if _passes_mapping(reference_sample, cell, args):

--- a/addons/gaea/graph/graph_nodes/root/map/placing/random_scatter.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/placing/random_scatter.gd
@@ -39,25 +39,25 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"reference", &"material"]
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Map:
-	var reference_sample: GaeaValue.Sample = _get_arg(&"reference", graph, pouch)
-	var material: GaeaMaterial = _get_arg(&"material", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Map:
+	var reference_sample: GaeaValue.Sample = _get_arg(&"reference", pouch)
+	var material: GaeaMaterial = _get_arg(&"material", pouch)
 
 	var result: GaeaValue.Map = GaeaValue.Map.new()
 	var cells_to_place_on: Array = reference_sample.get_cells()
 	cells_to_place_on.shuffle()
-	cells_to_place_on.resize(mini(_get_arg(&"amount", graph, pouch), cells_to_place_on.size()))
+	cells_to_place_on.resize(mini(_get_arg(&"amount", pouch), cells_to_place_on.size()))
 
 	var rng: RandomNumberGenerator = _get_rng(pouch)
 
 	material = material.prepare_sample(rng)
 	if not is_instance_valid(material):
-		material = _get_arg(&"material", graph, pouch)
+		material = _get_arg(&"material", pouch)
 		var error := (
 			"Recursive limit reached (%d): Invalid material provided at %s"
 			% [GaeaMaterial.RECURSIVE_LIMIT, material.resource_path]
 		)
-		_log_error(error, graph, graph.resources.find(self))
+		_log_error(error, graph.resources.find(self))
 		return result
 
 	for cell: Vector3i in cells_to_place_on:

--- a/addons/gaea/graph/graph_nodes/root/map/placing/rules_placer.gd
+++ b/addons/gaea/graph/graph_nodes/root/map/placing/rules_placer.gd
@@ -103,21 +103,20 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"reference", &"material"]
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Map:
-	var reference_sample: GaeaValue.Sample = _get_arg(&"reference", graph, pouch)
-	var material: GaeaMaterial = _get_arg(&"material", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Map:
+	var reference_sample: GaeaValue.Sample = _get_arg(&"reference", pouch)
+	var material: GaeaMaterial = _get_arg(&"material", pouch)
 	var result: GaeaValue.Map = GaeaValue.Map.new()
 
-	var rules: Dictionary = _get_arg(&"rules", graph, pouch)
+	var rules: Dictionary = _get_arg(&"rules", pouch)
 
 	var rng: RandomNumberGenerator = _get_rng(pouch)
 
 	material = material.prepare_sample(rng)
 	if not is_instance_valid(material):
-		material = _get_arg(&"material", graph, pouch)
+		material = _get_arg(&"material", pouch)
 		_log_error(
 			"Recursive limit reached (%d): Invalid material provided at %s" % [GaeaMaterial.RECURSIVE_LIMIT, material.resource_path],
-			graph,
 			id
 		)
 		return result

--- a/addons/gaea/graph/graph_nodes/root/other/composition/compose_range.gd
+++ b/addons/gaea/graph/graph_nodes/root/other/composition/compose_range.gd
@@ -41,8 +41,8 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.RANGE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Dictionary[String, float]:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Dictionary[String, float]:
 	return {
-		"min": _get_arg(&"min", graph, pouch),
-		"max": _get_arg(&"max", graph, pouch),
+		"min": _get_arg(&"min", pouch),
+		"max": _get_arg(&"max", pouch),
 	}

--- a/addons/gaea/graph/graph_nodes/root/sampling/basic/fill.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/basic/fill.gd
@@ -28,8 +28,8 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
-	var value: float = _get_arg(&"value", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+	var value: float = _get_arg(&"value", pouch)
 	var sample := GaeaValue.Sample.new()
 	sample.fill(pouch.area, value)
 	return sample

--- a/addons/gaea/graph/graph_nodes/root/sampling/border/border.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/border/border.gd
@@ -54,10 +54,10 @@ func _get_required_arguments() -> Array[StringName]:
 	return [&"sample"]
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
-	var neighbors: Array = _get_arg(&"neighbors", graph, pouch)
-	var inside: bool = _get_arg(&"inside", graph, pouch)
-	var input_sample: GaeaValue.Sample = _get_arg(&"sample", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+	var neighbors: Array = _get_arg(&"neighbors", pouch)
+	var inside: bool = _get_arg(&"inside", pouch)
+	var input_sample: GaeaValue.Sample = _get_arg(&"sample", pouch)
 
 	var border: GaeaValue.Sample = GaeaValue.Sample.new()
 	for x in _get_axis_range(Vector3i.AXIS_X, pouch.area):

--- a/addons/gaea/graph/graph_nodes/root/sampling/filters/filter.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/filters/filter.gd
@@ -35,14 +35,14 @@ func _get_output_port_display_name(output_name: StringName) -> String:
 	return super(output_name)
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.GridType:
-	var input_sample: GaeaValue.GridType = _get_arg(&"input_grid", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.GridType:
+	var input_sample: GaeaValue.GridType = _get_arg(&"input_grid", pouch)
 	var new_data: GaeaValue.GridType = GaeaValue.get_default_value(_get_output_port_type(_output_port))
 	var args: Dictionary[StringName, Variant]
 	for arg in get_arguments_list():
 		if arg == &"input_grid":
 			continue
-		args.set(arg, _get_arg(arg, graph, pouch))
+		args.set(arg, _get_arg(arg, pouch))
 
 	for cell: Vector3i in input_sample.get_cells():
 		if _passes_filter(input_sample, cell, args, pouch):

--- a/addons/gaea/graph/graph_nodes/root/sampling/generation/falloff_map.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/generation/falloff_map.gd
@@ -168,9 +168,9 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
-	var start: float = _get_arg(&"start", graph, pouch)
-	var end: float = _get_arg(&"end", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+	var start: float = _get_arg(&"start", pouch)
+	var end: float = _get_arg(&"end", pouch)
 	var result: GaeaValue.Sample = GaeaValue.Sample.new()
 	var sampler: FalloffSampler
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/sampling/generation/floor_walker.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/generation/floor_walker.gd
@@ -113,29 +113,29 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
-	_log_data(_output_port, graph)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+	_log_data(_output_port)
 	var axis_type: AxisType = get_enum_selection(0) as AxisType
 
-	var starting_position: Vector3 = _get_arg(&"starting_position", graph, pouch)
+	var starting_position: Vector3 = _get_arg(&"starting_position", pouch)
 	starting_position = starting_position.round()
 
 	var rotation_weights: Dictionary = {
-		PI * 0.5: _get_arg(&"rotate_90_weight", graph, pouch),
-		-PI * 0.5: _get_arg(&"rotate_-90_weight", graph, pouch),
-		PI: _get_arg(&"rotate_180_weight", graph, pouch)
+		PI * 0.5: _get_arg(&"rotate_90_weight", pouch),
+		-PI * 0.5: _get_arg(&"rotate_-90_weight", pouch),
+		PI: _get_arg(&"rotate_180_weight", pouch)
 	}
 	var direction_change_chance: float = (
-		float(_get_arg(&"direction_change_chance", graph, pouch)) * 0.01
+		float(_get_arg(&"direction_change_chance", pouch)) * 0.01
 	)
-	var new_walker_chance: float = float(_get_arg(&"new_walker_chance", graph, pouch)) * 0.01
+	var new_walker_chance: float = float(_get_arg(&"new_walker_chance", pouch)) * 0.01
 	var destroy_walker_chance: float = (
-		float(_get_arg(&"destroy_walker_chance", graph, pouch)) * 0.01
+		float(_get_arg(&"destroy_walker_chance", pouch)) * 0.01
 	)
-	var bigger_room_chance: float = float(_get_arg(&"bigger_room_chance", graph, pouch)) * 0.01
-	var bigger_room_size_range: Dictionary = _get_arg(&"bigger_room_size_range", graph, pouch)
+	var bigger_room_chance: float = float(_get_arg(&"bigger_room_chance", pouch)) * 0.01
+	var bigger_room_size_range: Dictionary = _get_arg(&"bigger_room_size_range", pouch)
 
-	var max_cells: int = _get_arg(&"max_cells", graph, pouch)
+	var max_cells: int = _get_arg(&"max_cells", pouch)
 	max_cells = mini(
 		max_cells,
 		(

--- a/addons/gaea/graph/graph_nodes/root/sampling/generation/snake_path_2d.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/generation/snake_path_2d.gd
@@ -77,16 +77,16 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
 	var direction_weights: Dictionary[Vector2i, float] = {
-		Vector2i.LEFT: _get_arg(&"move_left_weight", graph, pouch),
-		Vector2i.RIGHT: _get_arg(&"move_right_weight", graph, pouch),
-		Vector2i.DOWN: _get_arg(&"move_down_weight", graph, pouch),
+		Vector2i.LEFT: _get_arg(&"move_left_weight", pouch),
+		Vector2i.RIGHT: _get_arg(&"move_right_weight", pouch),
+		Vector2i.DOWN: _get_arg(&"move_down_weight", pouch),
 	}
-	var left_flag: int = _get_arg(&"left", graph, pouch)
-	var right_flag: int = _get_arg(&"right", graph, pouch)
-	var down_flag: int = _get_arg(&"down", graph, pouch)
-	var up_flag: int = _get_arg(&"up", graph, pouch)
+	var left_flag: int = _get_arg(&"left", pouch)
+	var right_flag: int = _get_arg(&"right", pouch)
+	var down_flag: int = _get_arg(&"down", pouch)
+	var up_flag: int = _get_arg(&"up", pouch)
 	var direction_to_flags: Dictionary = {
 		Vector2i.LEFT: left_flag,
 		Vector2i.RIGHT: right_flag,

--- a/addons/gaea/graph/graph_nodes/root/sampling/noise/noise.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/noise/noise.gd
@@ -63,14 +63,14 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
 	var noise: FastNoiseLite = FastNoiseLite.new()
 	noise.seed = pouch.settings.seed + salt
 	noise.noise_type = get_enum_selection(0) as FastNoiseLite.NoiseType
 
-	noise.frequency = _get_arg(&"frequency", graph, pouch)
-	noise.fractal_octaves = _get_arg(&"octaves", graph, pouch)
-	noise.fractal_lacunarity = _get_arg(&"lacunarity", graph, pouch)
+	noise.frequency = _get_arg(&"frequency", pouch)
+	noise.fractal_octaves = _get_arg(&"octaves", pouch)
+	noise.fractal_lacunarity = _get_arg(&"lacunarity", pouch)
 	var result: GaeaValue.Sample = GaeaValue.Sample.new()
 	for x in _get_axis_range(Vector3i.AXIS_X, pouch.area):
 		for y in _get_axis_range(Vector3i.AXIS_Y, pouch.area):

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
@@ -105,10 +105,10 @@ func _get_output_port_display_name(_output_name: StringName) -> String:
 	return operation_definitions[get_enum_selection(0)].output
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
 	var operation: Operation = get_enum_selection(0) as Operation
-	var a_grid: GaeaValue.Sample = _get_arg(&"a", graph, pouch)
-	var b_grid: GaeaValue.Sample = _get_arg(&"b", graph, pouch)
+	var a_grid: GaeaValue.Sample = _get_arg(&"a", pouch)
+	var b_grid: GaeaValue.Sample = _get_arg(&"b", pouch)
 	var result: GaeaValue.Sample = GaeaValue.Sample.new()
 	var operation_definition: Definition = operation_definitions[operation]
 	var static_args: Array
@@ -116,7 +116,7 @@ func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGeneration
 		if _get_argument_type(arg) == GaeaValue.Type.SAMPLE:
 			continue
 
-		static_args.append(_get_arg(arg, graph, pouch))
+		static_args.append(_get_arg(arg, pouch))
 	for cell: Vector3i in a_grid.get_cells():
 		if not b_grid.has(cell):
 			continue

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
@@ -62,15 +62,15 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 	return definitions
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
 	var operation: Operation = get_enum_selection(0) as Operation
 	var operation_definition: Definition = operation_definitions[operation]
 	var args: Array
-	var input_grid: GaeaValue.Sample = _get_arg(&"a", graph, pouch)
+	var input_grid: GaeaValue.Sample = _get_arg(&"a", pouch)
 	for arg_name: StringName in operation_definitions[operation].args:
 		if arg_name == &"a":
 			continue
-		args.append(_get_arg(arg_name, graph, pouch))
+		args.append(_get_arg(arg_name, pouch))
 	var result: GaeaValue.Sample = GaeaValue.Sample.new()
 	var grid_value_pos: int = _get_arguments_list().find(&"a")
 

--- a/addons/gaea/graph/graph_nodes/root/sampling/samplers/matrix_sampler.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/samplers/matrix_sampler.gd
@@ -33,11 +33,11 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
+func _get_data(output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 	assert(output_port == &"result", "Invalid output_port")
-	var data_x: GaeaValue.Sample = _get_arg(&"x", graph, pouch)
-	var data_y: GaeaValue.Sample = _get_arg(&"y", graph, pouch)
-	var matrix: GaeaValue.Sample = _get_arg(&"matrix", graph, pouch)
+	var data_x: GaeaValue.Sample = _get_arg(&"x", pouch)
+	var data_y: GaeaValue.Sample = _get_arg(&"y", pouch)
+	var matrix: GaeaValue.Sample = _get_arg(&"matrix", pouch)
 	var result: GaeaValue.Sample = GaeaValue.Sample.new()
 	for x in _get_axis_range(Vector3i.AXIS_X, pouch.area):
 		for y in _get_axis_range(Vector3i.AXIS_Y, pouch.area):

--- a/addons/gaea/graph/graph_nodes/root/sampling/samplers/texture_sampler.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/samplers/texture_sampler.gd
@@ -34,8 +34,8 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
-	var texture: Texture = _get_arg(&"texture", graph, pouch)
+func _get_data(output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+	var texture: Texture = _get_arg(&"texture", pouch)
 	if not is_instance_valid(texture):
 		return GaeaValue.get_default_value(GaeaValue.Type.SAMPLE)
 

--- a/addons/gaea/graph/graph_nodes/root/sampling/transformation/to_height.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/transformation/to_height.gd
@@ -87,12 +87,12 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.SAMPLE
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
-	var sample_reference: GaeaValue.Sample = _get_arg(&"reference", graph, pouch)
-	var row: int = _get_arg(&"reference_y", graph, pouch)
-	var height_offset: int = _get_arg(&"height_offset", graph, pouch)
-	var displacement: int = _get_arg(&"displacement_intensity", graph, pouch)
-	var gradient_intensity: float = _get_arg(&"gradient_intensity", graph, pouch)
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
+	var sample_reference: GaeaValue.Sample = _get_arg(&"reference", pouch)
+	var row: int = _get_arg(&"reference_y", pouch)
+	var height_offset: int = _get_arg(&"height_offset", pouch)
+	var displacement: int = _get_arg(&"displacement_intensity", pouch)
+	var gradient_intensity: float = _get_arg(&"gradient_intensity", pouch)
 	var result: GaeaValue.Sample = GaeaValue.Sample.new()
 	var type: Type = get_enum_selection(0) as Type
 

--- a/addons/gaea/graph/graph_nodes/root/vector/composition/compose_vector.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/composition/compose_vector.gd
@@ -64,28 +64,28 @@ func _get_tree_items() -> Array[GaeaNodeResource]:
 	return array
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 	match get_enum_selection(0):
 		VectorType.VECTOR2:
 			return Vector2(
-				_get_arg(&"x", graph, pouch),
-				_get_arg(&"y", graph, pouch),
+				_get_arg(&"x", pouch),
+				_get_arg(&"y", pouch),
 			)
 		VectorType.VECTOR3:
 			return Vector3(
-				_get_arg(&"x", graph, pouch),
-				_get_arg(&"y", graph, pouch),
-				_get_arg(&"z", graph, pouch),
+				_get_arg(&"x", pouch),
+				_get_arg(&"y", pouch),
+				_get_arg(&"z", pouch),
 			)
 		VectorType.VECTOR2I:
 			return Vector2i(
-				_get_arg(&"x", graph, pouch),
-				_get_arg(&"y", graph, pouch),
+				_get_arg(&"x", pouch),
+				_get_arg(&"y", pouch),
 			)
 		VectorType.VECTOR3I:
 			return Vector3i(
-				_get_arg(&"x", graph, pouch),
-				_get_arg(&"y", graph, pouch),
-				_get_arg(&"z", graph, pouch),
+				_get_arg(&"x", pouch),
+				_get_arg(&"y", pouch),
+				_get_arg(&"z", pouch),
 			)
 	return null

--- a/addons/gaea/graph/graph_nodes/root/vector/composition/decompose_vector.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/composition/decompose_vector.gd
@@ -64,5 +64,5 @@ func _get_tree_items() -> Array[GaeaNodeResource]:
 	return array
 
 
-func _get_data(output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> float:
-	return _get_arg(&"vector", graph, pouch)[output_port]
+func _get_data(output_port: StringName, pouch: GaeaGenerationPouch) -> float:
+	return _get_arg(&"vector", pouch)[output_port]

--- a/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
@@ -120,11 +120,11 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return get_enum_selection(0) as GaeaValue.Type
 
 
-func _get_data(_output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
+func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 	var operation: Operation = get_enum_selection(1) as Operation
 	var args: Array
 	for arg_name: StringName in operation_definitions[operation].args:
-		args.append(_get_arg(arg_name, graph, pouch))
+		args.append(_get_arg(arg_name, pouch))
 	return _get_new_value(operation, args)
 
 

--- a/addons/gaea/graph/graph_nodes/special/invalid/invalid_script_node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/special/invalid/invalid_script_node_resource.gd
@@ -60,5 +60,5 @@ func _get_scene_script() -> GDScript:
 	return load("uid://wlocahhk6rt")
 
 
-func _get_data(_output_port: StringName, _graph: GaeaGraph, _pouch: GaeaGenerationPouch) -> Dictionary[String, float]:
+func _get_data(_output_port: StringName, _pouch: GaeaGenerationPouch) -> Dictionary[String, float]:
 	return {}

--- a/addons/gaea/graph/graph_nodes/special/output/output_node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/special/output/output_node_resource.gd
@@ -16,15 +16,9 @@ func _get_title() -> String:
 
 
 func _get_arguments_list() -> Array[StringName]:
-	if not is_instance_valid(node) or not node is GaeaGraphNode:
-		return []
-	var graph: GaeaGraph = (node as GaeaGraphNode).graph_edit.graph
-
-	var layers: Array[StringName]
-	if node is GaeaGraphNode:
-		for layer_idx in graph.layers.size():
-			layers.append(&"%d" % layer_idx)
-
+	var layers: Array[StringName] = []
+	for layer_idx in graph.layers.size():
+		layers.append(&"%d" % layer_idx)
 	return layers
 
 
@@ -33,10 +27,6 @@ func _get_argument_type(_arg_name: StringName) -> GaeaValue.Type:
 
 
 func _get_argument_display_name(arg_name: StringName) -> String:
-	if not is_instance_valid(node) or not node is GaeaGraphNode:
-		return ""
-	var graph: GaeaGraph = (node as GaeaGraphNode).graph_edit.graph
-
 	var idx: int = int(arg_name)
 	if graph.layers.size() < idx:
 		return "Invalid Layer"
@@ -67,9 +57,9 @@ func _get_argument_connection(arg_name: StringName) -> Dictionary:
 
 
 ## Start generation for [param area], using [param pouch]'s pouch.
-func execute(graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaGrid:
+func execute(pouch: GaeaGenerationPouch) -> GaeaGrid:
 	var start_time := Time.get_ticks_msec()
-	_log_execute("Start", pouch.area, graph)
+	_log_execute("Start", pouch.area)
 
 	var grid: GaeaGrid = GaeaGrid.new()
 	for layer_idx in graph.layers.size():
@@ -78,16 +68,17 @@ func execute(graph: GaeaGraph, pouch: GaeaGenerationPouch) -> GaeaGrid:
 			grid.add_layer(layer_idx, null, layer_resource)
 			continue
 
-		_log_layer("Start", layer_idx, graph)
+		_log_layer("Start", layer_idx)
 
-		var grid_data: GaeaValue.Map = _get_arg(&"%d" % layer_idx, graph, pouch)
+		var grid_data: GaeaValue.Map = _get_arg(&"%d" % layer_idx, pouch)
 		grid.add_layer(layer_idx, grid_data, layer_resource)
 		traversed.emit(&"%d" % layer_idx, grid, pouch)
 
-		_log_layer("End", layer_idx, graph)
+		_log_layer("End", layer_idx)
 
-	_log_execute("End", pouch.area, graph)
-	_log_time("Generation", Time.get_ticks_msec() - start_time, graph)
+	_log_execute("End", pouch.area)
+	_log_time("Generation", Time.get_ticks_msec() - start_time)
+
 	return grid
 
 
@@ -109,5 +100,5 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 	return GaeaValue.Type.NULL
 
 
-func _get_data(_output_port: StringName, _graph: GaeaGraph, _pouch: GaeaGenerationPouch) -> Variant:
+func _get_data(_output_port: StringName, _pouch: GaeaGenerationPouch) -> Variant:
 	return null

--- a/addons/gaea/graph/graph_nodes/special/reroute/reroute_node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/special/reroute/reroute_node_resource.gd
@@ -48,11 +48,11 @@ func _get_scene() -> PackedScene:
 	return load("uid://b2rceqo8rtr88")
 
 
-func _get_data(output_port: StringName, graph: GaeaGraph, pouch: GaeaGenerationPouch) -> Variant:
-	return _get_arg(output_port, graph, pouch)
+func _get_data(output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
+	return _get_arg(output_port, pouch)
 
 
-func _use_caching(_output_port: StringName, _graph: GaeaGraph) -> bool:
+func _use_caching(_output_port: StringName) -> bool:
 	return false
 
 

--- a/addons/gaea/nodes/threading/generation_task.gd
+++ b/addons/gaea/nodes/threading/generation_task.gd
@@ -15,7 +15,7 @@ var _results_dict: Dictionary[int, GaeaValue.Map]
 ## [param graph]'s execute method with [param task_pouch]'s
 ## [member GaeaGenerationPouch.area].
 func _init(task_description: String, graph: GaeaGraph, task_pouch: GaeaGenerationPouch):
-	var new_task = graph.get_output_node().execute.bind(graph, task_pouch)
+	var new_task = graph.get_output_node().execute.bind(task_pouch)
 	pouch = task_pouch
 	super._init(
 		new_task, task_description,

--- a/testing/graph_nodes/operations/num_op.gd
+++ b/testing/graph_nodes/operations/num_op.gd
@@ -19,7 +19,7 @@ func _assert_operation_result(args: Array[Variant], expected: float) -> void:
 
 	for i in node.get_arguments_list().size():
 		node.set_argument_value(node.get_arguments_list()[i], args[i])
-	var result: float = node._get_data(&"result", graph, pouch)
+	var result: float = node._get_data(&"result", pouch)
 	assert_that(result)\
 		.override_failure_message(_get_failure_message())\
 		.append_failure_message("Arguments: %s\n Expected result: %s\n Returned result: %s" % [args, expected, result])\

--- a/testing/graph_nodes/operations/sample_op.gd
+++ b/testing/graph_nodes/operations/sample_op.gd
@@ -20,7 +20,7 @@ func _assert_operation_result(args: Array[Variant], expected: float) -> void:
 			sample.set_cell(Vector3i(0, 1, 0), args[i])
 			args[i] = sample
 		node.set_argument_value(node.get_arguments_list()[i], args[i])
-	var grid: GaeaValue.Sample = node._get_data(&"result", graph, pouch)
+	var grid: GaeaValue.Sample = node._get_data(&"result", pouch)
 	assert_bool(grid.is_empty())\
 		.override_failure_message("[b]GaeaNodeSampleOp[/b] returned an empty grid with operation [b]%s[/b]."
 			% GaeaNodeSampleOp.Operation.keys()[node.get_enum_selection(0)])\

--- a/testing/graph_nodes/operations/samples_op.gd
+++ b/testing/graph_nodes/operations/samples_op.gd
@@ -23,7 +23,7 @@ func _assert_operation_result(args: Array[Variant], expected: float) -> void:
 			sample.set_cell(Vector3i(0, 1, 0), args[i])
 			args[i] = sample
 		node.set_argument_value(node.get_arguments_list()[i], args[i])
-	var grid: GaeaValue.Sample = node._get_data(&"result", graph, pouch)
+	var grid: GaeaValue.Sample = node._get_data(&"result", pouch)
 	assert_bool(grid.is_empty())\
 		.override_failure_message("[b]GaeaNodeSampleOp[/b] returned an empty grid with operation [b]%s[/b]."
 			% GaeaNodeSamplesOp.Operation.keys()[node.get_enum_selection(0)])\

--- a/testing/test_grid_output_base.gd
+++ b/testing/test_grid_output_base.gd
@@ -22,7 +22,7 @@ func _assert_output_grid_matches(
 	graph.ensure_initialized()
 	graph.add_node(node, Vector2i.ZERO)
 
-	var generated_data: GaeaValue.GridType = node._get_data(output, graph, pouch)
+	var generated_data: GaeaValue.GridType = node._get_data(output, pouch)
 	assert_bool(is_instance_valid(generated_data))\
 		.override_failure_message(
 			"Invalid result from [b]%s[b]" % node.get_tree_name()


### PR DESCRIPTION
This PR is the first step for #573

The idea here is to have a reference of the "owning" GareGraph on the GaeaNodeResource instead of passing around the reference. Because a lot of funtions inside GaeaNodeResource does use the reference and a GaeaNodeResource can have only one GareGraph.

Also simplify the reference to the graph inside the output node and parameter nodes. The methods was using the node->graph_edit->graph reference that is not defined on an exported game. Not sure how that was working before during gameplay

Note: Any custom nodes will need to remove the graph param so it's better to do that now than later