### PR TITLE
Remove GraphNode reference from NodeResource

### DIFF
--- a/addons/gaea/editor/graph_editor/graph_edit.gd
+++ b/addons/gaea/editor/graph_editor/graph_edit.gd
@@ -129,12 +129,12 @@ func _load_connections(connections_list: Array[Dictionary]) -> void:
 		var from_node_resource := graph.get_node(connection.from_node)
 		if not is_instance_valid(from_node_resource):
 			continue
-		var from_node := from_node_resource.node
+		var from_node: GaeaGraphNode = from_node_resource.get_meta(&"_gaea_graph_node")
 
 		var to_node_resource := graph.get_node(connection.to_node)
 		if not is_instance_valid(to_node_resource):
 			continue
-		var to_node := to_node_resource.node
+		var to_node: GaeaGraphNode = to_node_resource.get_meta(&"_gaea_graph_node")
 
 		if not is_instance_valid(from_node) or not is_instance_valid(to_node):
 			continue
@@ -635,7 +635,7 @@ func _load_attached_elements(attached: Array, frame_name: StringName) -> void:
 			if attached_frame_idx != -1:
 				node = graph_children[attached_frame_idx]
 		else:
-			node = node_resource.node
+			node = node_resource.get_meta(&"_gaea_graph_node")
 
 		if not is_instance_valid(node):
 			continue

--- a/addons/gaea/graph/graph_nodes/graph_node.gd
+++ b/addons/gaea/graph/graph_nodes/graph_node.gd
@@ -65,7 +65,7 @@ func _on_added() -> void:
 	if not is_instance_valid(resource) or is_part_of_edited_scene():
 		return
 
-	resource.node = self
+	resource.set_meta(&"_gaea_graph_node", self)
 	resource.argument_list_changed.connect(_rebuild, CONNECT_DEFERRED)
 	resource.argument_hint_changed.connect(_on_argument_hint_changed, CONNECT_DEFERRED)
 

--- a/addons/gaea/graph/graph_nodes/node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/node_resource.gd
@@ -57,9 +57,6 @@ const GAEA_MATERIAL_GRADIENT_HINT := "Resource that maps values from 0.0-1.0 to 
 ## }
 ## [/codeblock]
 var connections: Array[Dictionary]
-## The related [GaeaGraphNode] for editing in the Gaea graph editor.
-## This is null during runtime.
-var node: GaeaGraphNode
 ## A Dictionary holding the values of the arguments
 ## where the keys are their names.
 var arguments: Dictionary

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
@@ -27,7 +27,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "SamplesOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
+	if get_tree_name() == "SamplesOp" and not is_instance_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 sample grids."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
@@ -27,7 +27,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "SamplesOp" and not has_meta(&"_gaea_graph_node"):
+	if get_tree_name() == "SamplesOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 sample grids."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
@@ -27,7 +27,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "SamplesOp" and not is_instance_valid(node):
+	if get_tree_name() == "SamplesOp" and not has_meta(&"_gaea_graph_node"):
 		return "Operation between 2 sample grids."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
@@ -9,7 +9,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "SampleOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
+	if get_tree_name() == "SampleOp" and not is_instance_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between a sample grid and a [code]float[/code] number."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
@@ -9,7 +9,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "SampleOp" and not is_instance_valid(node):
+	if get_tree_name() == "SampleOp" and not has_meta(&"_gaea_graph_node"):
 		return "Operation between a sample grid and a [code]float[/code] number."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
@@ -9,7 +9,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "SampleOp" and not has_meta(&"_gaea_graph_node"):
+	if get_tree_name() == "SampleOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between a sample grid and a [code]float[/code] number."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/scalar/operations/float_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/scalar/operations/float_operation.gd
@@ -9,7 +9,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "FloatOp" and not has_meta(&"_gaea_graph_node"):
+	if get_tree_name() == "FloatOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 [code]float[/code] numbers."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/scalar/operations/float_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/scalar/operations/float_operation.gd
@@ -9,7 +9,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "FloatOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
+	if get_tree_name() == "FloatOp" and not is_instance_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 [code]float[/code] numbers."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/scalar/operations/float_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/scalar/operations/float_operation.gd
@@ -9,7 +9,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "FloatOp" and not is_instance_valid(node):
+	if get_tree_name() == "FloatOp" and not has_meta(&"_gaea_graph_node"):
 		return "Operation between 2 [code]float[/code] numbers."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/scalar/operations/int_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/scalar/operations/int_operation.gd
@@ -13,7 +13,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "IntOp" and not is_instance_valid(node):
+	if get_tree_name() == "IntOp" and not has_meta(&"_gaea_graph_node"):
 		return "Operation between 2 [code]int[/code] numbers."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/scalar/operations/int_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/scalar/operations/int_operation.gd
@@ -13,7 +13,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "IntOp" and not has_meta(&"_gaea_graph_node"):
+	if get_tree_name() == "IntOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 [code]int[/code] numbers."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/scalar/operations/int_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/scalar/operations/int_operation.gd
@@ -13,7 +13,7 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 
 
 func _get_description() -> String:
-	if get_tree_name() == "IntOp" and not instance_is_valid(get_meta(&"_gaea_graph_node")):
+	if get_tree_name() == "IntOp" and not is_instance_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 [code]int[/code] numbers."
 
 	match get_enum_selection(0):

--- a/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
@@ -31,7 +31,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == _get_title() and not instance_is_valid(get_meta(&"_gaea_graph_node")):
+	if get_tree_name() == _get_title() and not is_instance_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 [code]Vector[/code]s."
 
 	var vector_name := _get_enum_option_display_name(0, get_enum_selection(0))

--- a/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
@@ -31,7 +31,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == _get_title() and not has_meta(&"_gaea_graph_node"):
+	if get_tree_name() == _get_title() and not instance_is_valid(get_meta(&"_gaea_graph_node")):
 		return "Operation between 2 [code]Vector[/code]s."
 
 	var vector_name := _get_enum_option_display_name(0, get_enum_selection(0))

--- a/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/graph/graph_nodes/root/vector/operations/vector_operation.gd
@@ -31,7 +31,7 @@ func _get_title() -> String:
 
 
 func _get_description() -> String:
-	if get_tree_name() == _get_title() and not is_instance_valid(node):
+	if get_tree_name() == _get_title() and not has_meta(&"_gaea_graph_node"):
 		return "Operation between 2 [code]Vector[/code]s."
 
 	var vector_name := _get_enum_option_display_name(0, get_enum_selection(0))

--- a/addons/gaea/graph/graph_nodes/special/reroute/reroute_node.gd
+++ b/addons/gaea/graph/graph_nodes/special/reroute/reroute_node.gd
@@ -21,7 +21,7 @@ func _on_added() -> void:
 	if not is_instance_valid(resource) or is_part_of_edited_scene():
 		return
 
-	resource.node = self
+	resource.set_meta(&"_gaea_graph_node", self)
 	resource.argument_list_changed.connect(on_type_changed)
 
 	var titlebar_hbox = get_titlebar_hbox()


### PR DESCRIPTION
This PR is an other step for #573

This PR remove the `node` property from the `GaeaGraphNode` class.
It's now using instead a meta value with the key `&"_gaea_graph_node"`.
