### PR TITLE
Escape GaeaEditorSettings calls during runtime

### DIFF
--- a/addons/gaea/editor/graph_editor/graph_edit.gd
+++ b/addons/gaea/editor/graph_editor/graph_edit.gd
@@ -774,7 +774,7 @@ func _on_scroll_offset_changed(offset: Vector2) -> void:
 
 
 func _on_editor_script_changed(script: Script):
-	var editor := EditorInterface.get_script_editor().get_current_editor()
+	var editor: ScriptEditorBase = EditorInterface.get_script_editor().get_current_editor()
 	if not editor.edited_script_changed.is_connected(_on_edited_script_changed):
 		editor.edited_script_changed.connect(_on_edited_script_changed.bind(script))
 

--- a/addons/gaea/graph/graph_nodes/graph_node.gd
+++ b/addons/gaea/graph/graph_nodes/graph_node.gd
@@ -237,6 +237,7 @@ func _open_preview(for_output: StringName) -> void:
 
 func _set_titlebar() -> void:
 	var type: GaeaValue.Type = resource.get_type()
+	var base_color: Color = resource.get_title_color()
 	var titlebar: StyleBoxFlat
 	var titlebar_selected: StyleBoxFlat
 	if type != GaeaValue.Type.NULL:
@@ -246,19 +247,19 @@ func _set_titlebar() -> void:
 			not _titlebar_styleboxes.has(type)
 			or (
 				_titlebar_styleboxes.get(type).get("for_color", Color.TRANSPARENT)
-				!= resource.get_title_color()
+				!= base_color
 			)
 		):
 			titlebar = get_theme_stylebox("titlebar", "GraphNode").duplicate()
 			titlebar_selected = get_theme_stylebox("titlebar_selected", "GraphNode").duplicate()
-			titlebar.bg_color = titlebar.bg_color.blend(Color(resource.get_title_color(), 0.3))
+			titlebar.bg_color = titlebar.bg_color.blend(Color(base_color, 0.3))
 			titlebar_selected.bg_color = titlebar.bg_color
 			_titlebar_styleboxes.set(
 				type,
 				{
 					"titlebar": titlebar,
 					"selected": titlebar_selected,
-					"for_color": resource.get_title_color()
+					"for_color": base_color
 				}
 			)
 		else:

--- a/addons/gaea/graph/graph_nodes/special/output/output_node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/special/output/output_node_resource.gd
@@ -99,6 +99,7 @@ func _get_scene_script() -> GDScript:
 ## Output nodes have a special titlebar color.
 func get_title_color() -> Color:
 	if Engine.is_editor_hint():
+		# gdlint:ignore = duplicated-load
 		var gaea_editor_settings: GDScript = load("uid://duu3vekk7pxwk")
 		return gaea_editor_settings.get_configured_output_color()
 	return super()

--- a/addons/gaea/graph/graph_nodes/special/output/output_node_resource.gd
+++ b/addons/gaea/graph/graph_nodes/special/output/output_node_resource.gd
@@ -98,7 +98,10 @@ func _get_scene_script() -> GDScript:
 
 ## Output nodes have a special titlebar color.
 func get_title_color() -> Color:
-	return GaeaEditorSettings.get_configured_output_color()
+	if Engine.is_editor_hint():
+		var gaea_editor_settings: GDScript = load("uid://duu3vekk7pxwk")
+		return gaea_editor_settings.get_configured_output_color()
+	return super()
 
 
 func _get_output_ports_list() -> Array[StringName]:

--- a/addons/gaea/resources/gaea_value.gd
+++ b/addons/gaea/resources/gaea_value.gd
@@ -213,8 +213,8 @@ static func get_display_icon(type: Type) -> Texture2D:
 		Type.MATERIAL:
 			return load("uid://b0vqox8bodse")
 		Type.TEXTURE:
-			var editor_interface = Engine.get_singleton("EditorInterface")
-			return editor_interface.get_base_control().get_theme_icon(&"Image", &"EditorIcons")
+			if Engine.is_editor_hint():
+				return Engine.get_singleton("EditorInterface").get_base_control().get_theme_icon(&"Image", &"EditorIcons")
 		# Dictionary types
 		Type.SAMPLE:
 			return load("uid://dkccxw7yq1mth")
@@ -246,7 +246,8 @@ static func get_default_slot_icon(type: Type) -> Texture2D:
 		Type.VECTOR3I, Type.VECTOR3:
 			return load("uid://dbvw3j8fnmhpu")
 		Type.ANY:
-			return EditorInterface.get_editor_theme().get_icon("NodeInfo", "EditorIcons")
+			if Engine.is_editor_hint():
+				return Engine.get_singleton(&"EditorInterface").get_editor_theme().get_icon("NodeInfo", "EditorIcons")
 		# Simple types
 		Type.RANGE:
 			return load("uid://dfsmxavxasx7x")

--- a/addons/gaea/resources/gaea_value.gd
+++ b/addons/gaea/resources/gaea_value.gd
@@ -214,7 +214,7 @@ static func get_display_icon(type: Type) -> Texture2D:
 			return load("uid://b0vqox8bodse")
 		Type.TEXTURE:
 			if Engine.is_editor_hint():
-				return Engine.get_singleton("EditorInterface").get_base_control().get_theme_icon(&"Image", &"EditorIcons")
+				return Engine.get_singleton(&"EditorInterface").get_base_control().get_theme_icon(&"Image", &"EditorIcons")
 		# Dictionary types
 		Type.SAMPLE:
 			return load("uid://dkccxw7yq1mth")

--- a/addons/gaea/resources/gaea_value.gd
+++ b/addons/gaea/resources/gaea_value.gd
@@ -69,13 +69,6 @@ static func get_type_string(type: Type) -> String:
 	return String(Type.find_key(type)).capitalize().replace(" ", "")
 
 
-## Returns the configured color for slots of [param type].
-static func get_color(type: Type) -> Color:
-	if GaeaEditorSettings.CONFIGURABLE_SLOT_COLORS.has(type):
-		return GaeaEditorSettings.get_configured_color_for_value_type(type)
-	return get_default_color(type)
-
-
 ## Returns the default value for [param type]. Returns [code]null[/code] if there's none.
 static func get_default_value(type: Type) -> Variant:
 	match type:
@@ -157,6 +150,15 @@ static func from_old_slot_type(old_type: int) -> GaeaValue.Type:
 	return GaeaValue.Type.NULL
 
 
+## Returns the configured color for slots of [param type].
+static func get_color(type: Type) -> Color:
+	if Engine.is_editor_hint():
+		var gaea_editor_settings: GDScript = load("uid://duu3vekk7pxwk")
+		if gaea_editor_settings.CONFIGURABLE_SLOT_COLORS.has(type):
+			return gaea_editor_settings.get_configured_color_for_value_type(type)
+	return get_default_color(type)
+
+
 ## Returns the default color for slots of [param type].
 static func get_default_color(type: Type) -> Color:
 	match type:
@@ -222,8 +224,10 @@ static func get_display_icon(type: Type) -> Texture2D:
 
 ## Returns the configured icon for slots of [param type].
 static func get_slot_icon(type: Type) -> Texture2D:
-	if GaeaEditorSettings.CONFIGURABLE_SLOT_COLORS.has(type):
-		return GaeaEditorSettings.get_configured_icon_for_value_type(type)
+	if Engine.is_editor_hint():
+		var gaea_editor_settings: GDScript = load("uid://duu3vekk7pxwk")
+		if gaea_editor_settings.CONFIGURABLE_SLOT_COLORS.has(type):
+			return gaea_editor_settings.get_configured_icon_for_value_type(type)
 	return get_default_slot_icon(type)
 
 

--- a/addons/gaea/resources/gaea_value.gd
+++ b/addons/gaea/resources/gaea_value.gd
@@ -153,6 +153,7 @@ static func from_old_slot_type(old_type: int) -> GaeaValue.Type:
 ## Returns the configured color for slots of [param type].
 static func get_color(type: Type) -> Color:
 	if Engine.is_editor_hint():
+		# gdlint:ignore = duplicated-load
 		var gaea_editor_settings: GDScript = load("uid://duu3vekk7pxwk")
 		if gaea_editor_settings.CONFIGURABLE_SLOT_COLORS.has(type):
 			return gaea_editor_settings.get_configured_color_for_value_type(type)
@@ -225,6 +226,7 @@ static func get_display_icon(type: Type) -> Texture2D:
 ## Returns the configured icon for slots of [param type].
 static func get_slot_icon(type: Type) -> Texture2D:
 	if Engine.is_editor_hint():
+		# gdlint:ignore = duplicated-load
 		var gaea_editor_settings: GDScript = load("uid://duu3vekk7pxwk")
 		if gaea_editor_settings.CONFIGURABLE_SLOT_COLORS.has(type):
 			return gaea_editor_settings.get_configured_icon_for_value_type(type)


### PR DESCRIPTION
This PR is an other part for #573 

The idea is to remove the reference of the `GaeaEditorSettings` class by loading directly it when needed.
+ Bonus optimization on the way