### PR TITLE
Fix GaeaNodesCopy serialization to text

### DIFF
--- a/addons/gaea/resources/gaea_nodes_copy.gd
+++ b/addons/gaea/resources/gaea_nodes_copy.gd
@@ -74,76 +74,76 @@ func get_node_position(id: int) -> Vector2:
 
 
 func serialize() -> String:
-	var nodes_data: Dictionary[int, Array] = {}
-	var connections: Array[String] = []
+	var nodes_data: Dictionary[int, Dictionary] = {}
+	var connections: Array[Array] = []
 
 	for node_id: int in _nodes.keys():
 		var node_properties: Dictionary = _nodes.get(node_id, {})
-		nodes_data.set(node_id, [
-			node_properties.get(&"type"),
-			node_properties.get(&"data"),
-		])
+		nodes_data.set(node_id, {
+			"type": node_properties.get(&"type"),
+			"data": node_properties.get(&"data"),
+		})
 
 	for connection in _connections:
-		if nodes_data.has(connection.from_node) and nodes_data.has(connection.to_node):
-			connections.append("%s-%s-%s-%s" % [
+		if nodes_data.has(connection.get("from_node")) and nodes_data.has(connection.get("to_node")):
+			connections.append([
 				connection.get("from_node"),
 				connection.get("from_port"),
 				connection.get("to_node"),
 				connection.get("to_port"),
 			])
 
-	return JSON.stringify({
-		"origin": _origin,
-		"nodes": nodes_data,
-		"connections": connections
-	}, "", false)
+	var data: Dictionary = { "origin": _origin, "nodes": nodes_data }
+	if connections.size() > 0:
+		data.set("connections", connections)
+
+	return var_to_str(data)
 
 
 ## Deserialize a previously serialized GaeaNodesCopy,
 ## return a GaeaNodesCopy object or a string as error message.
 static func deserialize(serialized: String) -> Variant:
-	var data = JSON.parse_string(serialized)
+	if serialized.contains("Object("):
+		return "Paste failed. The clipboard data includes a disallowed serialized object."
 
+	var deserialized_data = str_to_var(serialized)
 	if (
-		not data is Dictionary
-		or not data.get("origin") is Vector2
-		or not data.get("nodes") is Dictionary
-		or not data.get("connections") is Array
+		not deserialized_data is Dictionary
+		or not deserialized_data.get("origin") is Vector2
+		or not deserialized_data.get("nodes") is Dictionary
+		or not deserialized_data.get("connections", []) is Array
 	):
-		return "Invalid data provided: the data could not be parsed"
+		return "Invalid data provided: the data could not be parsed."
 
-	var origin: Vector2 = data[0]
+	var origin: Vector2 = deserialized_data.get("origin")
 	var deserialized: GaeaNodesCopy = GaeaNodesCopy.new(origin)
 
-	var nodes_data: Dictionary = data.get("nodes")
+	var nodes_data: Dictionary = deserialized_data.get("nodes")
 	for node_id in nodes_data.keys():
 		var node_data = nodes_data.get(node_id)
-		if typeof(node_id) != TYPE_INT or typeof(node_data) != TYPE_ARRAY or not node_data[1] is Dictionary:
-			return "Invalid data provided: the data could not be parsed"
-		match node_data[0]:
+		if not node_data.get("data") is Dictionary:
+			return "Invalid data provided: the data of node %d could not be parsed." % node_id
+		var data: Dictionary = node_data.get("data")
+		match node_data.get("type"):
 			GaeaGraph.NodeType.NODE:
-				var uid: String = node_data[1].get(&"uid")
+				var uid: String = data.get(&"uid")
 				var resource: GaeaNodeResource
 				if GaeaNodeResource.is_valid_node_resource(uid).is_empty():
 					resource = load(uid).new()
 				else:
 					resource = GaeaNodeInvalidScript.new()
-				resource.load_save_data(node_data[1])
-				deserialized.add_node(node_id, resource, node_data[1].get(&"position", origin), node_data[1])
+				resource.load_save_data(data)
+				deserialized.add_node(node_id, resource, data.get(&"position", origin), data)
 			GaeaGraph.NodeType.FRAME:
-				deserialized.add_frame(node_id, node_data[1].get(&"position", origin), node_data[1])
+				deserialized.add_frame(node_id, data.get(&"position", origin), data)
 			_:
 				return "Invalid data provided: the data could not be parsed"
 
-	var connections: Array = nodes_data.get("connections")
-	@warning_ignore("integer_division")
-	for connection_string: String in connections:
-		var split_string := connection_string.split("-")
+	for connection: Array in deserialized_data.get("connections", []):
 		deserialized.add_connection({
-			"from_node": int(split_string[0]),
-			"from_port": int(split_string[1]),
-			"to_node": int(split_string[2]),
-			"to_port": int(split_string[3])
+			"from_node": connection[0],
+			"from_port": connection[1],
+			"to_node": connection[2],
+			"to_port": connection[3],
 		})
 	return deserialized


### PR DESCRIPTION
I am not sure what happen in #560. I think I just copy paste the wrong code when rebasing but the serialize/deserialize just does not works.

I remplaced the JSON to a other text based string. The JSON format was too complex to deserialize the many custom types Godot offer. So the quick solution here is to use Godot built-in methods.

I know it's no more a JSON but it's still easy to read/edit

It's using the `var_to_str` and `str_to_var` but does not allow Object to be parsed for security reasons. See issue `#80562` on Godot repo.