### PR TITLE
Fix Dictionary[Operation, Definition] type

### DIFF
--- a/addons/gaea/runtime/graph_nodes/generic_classes/number_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/generic_classes/number_operation.gd
@@ -41,8 +41,37 @@ class Definition:
 
 
 ## All possible operations.
-var operation_definitions: Dictionary[Operation, Definition]:
-	get = _get_operation_definitions
+static var operation_definitions: Dictionary[Operation, Definition] = {
+	Operation.ADD: Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
+	Operation.SUBTRACT: Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
+	Operation.MULTIPLY: Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
+	Operation.DIVIDE: Definition.new(
+		[&"a", &"b"],
+		"a / b",
+		func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b
+	),
+	#Operation.REMAINDER: Definition.new([&"a", &"b"], "a % b", func(a: float, b: float): return 0.0 if is_zero_approx(b) else fmod(a, b)),
+	Operation.POWER: Definition.new([&"base", &"exp"], "base ** exp", pow),
+	Operation.MAX: Definition.new([&"a", &"b"], "max(a, b)", max),
+	Operation.MIN: Definition.new([&"a", &"b"], "min(a, b)", min),
+	#Operation.SNAPPED: Definition.new([&"a", "Step"], "snapped(a, step)", snapped),
+	Operation.ABS: Definition.new([&"a"], "abs(a)", abs),
+	Operation.CEIL: Definition.new([&"a"], "ceil(a)", ceil),
+	Operation.FLOOR: Definition.new([&"a"], "floor(a)", floor),
+	Operation.ROUND: Definition.new([&"a"], "round(a)", round),
+	Operation.CLAMP: Definition.new([&"a", &"min", &"max"], "clamp(a, min, max)", clamp),
+	#Operation.LERP: Definition.new([&"from", &"to", &"weight"], "lerpf(from, to, weight)", lerpf),
+	#Operation.LOG: Definition.new([&"a"], "log(a)", log),
+	Operation.REMAP: Definition.new(
+		[&"a", &"in_start", &"in_stop", &"out_start", &"out_stop"], "remap(a, ...)", remap
+	),
+	Operation.SIGN: Definition.new([&"a"], "sign(a)", sign),
+	Operation.SMOOTHSTEP: Definition.new([&"from", &"to", &"a"], "smoothstep(from, to, a)", smoothstep),
+	Operation.STEP: Definition.new(
+		[&"a", &"edge"], "step(a, edge)", func(a, edge): return 0 if a < edge else 1
+	),
+	Operation.WRAP: Definition.new([&"a", &"min", &"max"], "wrap(a, min, max)", wrap),
+}
 
 
 func _get_description() -> String:
@@ -140,63 +169,3 @@ func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 
 func _get_new_value(operation: Operation, args: Array) -> Variant:
 	return operation_definitions[operation].conversion.callv(args)
-
-
-func _get_operation_definitions() -> Dictionary[Operation, Definition]:
-	if not operation_definitions.is_empty():
-		return operation_definitions
-
-	operation_definitions.clear()
-	operation_definitions.assign({
-		Operation.ADD:
-			Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
-		Operation.SUBTRACT:
-			Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
-		Operation.MULTIPLY:
-			Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
-		Operation.DIVIDE:
-			Definition.new(
-				[&"a", &"b"],
-				"a / b",
-				func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b
-			),
-		#Operation.REMAINDER:
-		#Definition.new([&"a", &"b"], "a % b", func(a: float, b: float): return 0.0 if is_zero_approx(b) else fmod(a, b)),
-		Operation.POWER:
-			Definition.new([&"base", &"exp"], "base ** exp", pow),
-		Operation.MAX:
-			Definition.new([&"a", &"b"], "max(a, b)", max),
-		Operation.MIN:
-			Definition.new([&"a", &"b"], "min(a, b)", min),
-		#Operation.SNAPPED:
-		#Definition.new([&"a", "Step"], "snapped(a, step)", snapped),
-		Operation.ABS:
-			Definition.new([&"a"], "abs(a)", abs),
-		Operation.CEIL:
-			Definition.new([&"a"], "ceil(a)", ceil),
-		Operation.FLOOR:
-			Definition.new([&"a"], "floor(a)", floor),
-		Operation.ROUND:
-			Definition.new([&"a"], "round(a)", round),
-		Operation.CLAMP:
-			Definition.new([&"a", &"min", &"max"], "clamp(a, min, max)", clamp),
-		#Operation.LERP:
-		#Definition.new([&"from", &"to", &"weight"], "lerpf(from, to, weight)", lerpf),
-		#Operation.LOG:
-		#Definition.new([&"a"], "log(a)", log),
-		Operation.REMAP:
-			Definition.new(
-				[&"a", &"in_start", &"in_stop", &"out_start", &"out_stop"], "remap(a, ...)", remap
-			),
-		Operation.SIGN:
-			Definition.new([&"a"], "sign(a)", sign),
-		Operation.SMOOTHSTEP:
-			Definition.new([&"from", &"to", &"a"], "smoothstep(from, to, a)", smoothstep),
-		Operation.STEP:
-			Definition.new(
-				[&"a", &"edge"], "step(a, edge)", func(a, edge): return 0 if a < edge else 1
-			),
-		Operation.WRAP:
-			Definition.new([&"a", &"min", &"max"], "wrap(a, min, max)", wrap),
-	})
-	return operation_definitions

--- a/addons/gaea/runtime/graph_nodes/generic_classes/number_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/generic_classes/number_operation.gd
@@ -41,7 +41,7 @@ class Definition:
 
 
 ## All possible operations.
-static var operation_definitions: Dictionary[Operation, Definition] = {
+static var _number_operation_definitions: Dictionary[Operation, Definition] = {
 	Operation.ADD: Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
 	Operation.SUBTRACT: Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
 	Operation.MULTIPLY: Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
@@ -110,6 +110,7 @@ otherwise returns an interpolated value between [code]0[/code] and [code]1[/code
 func _get_tree_items() -> Array[GaeaNodeResource]:
 	var items: Array[GaeaNodeResource]
 	items.append_array(super())
+	var operation_definitions: Dictionary[Operation, Definition] = _get_operation_definitions()
 	for operation in operation_definitions.keys():
 		var item: GaeaNodeResource = get_script().new()
 		var operation_name: String = Operation.find_key(operation).to_pascal_case()
@@ -129,14 +130,14 @@ func _get_enums_count() -> int:
 func _get_enum_options(_idx: int) -> Dictionary:
 	var options: Dictionary = {}
 
-	for operation in operation_definitions.keys():
+	for operation in _get_operation_definitions().keys():
 		options.set(Operation.find_key(operation), operation)
 
 	return options
 
 
 func _get_arguments_list() -> Array[StringName]:
-	return operation_definitions.get(get_enum_selection(0)).args
+	return _get_operation_definitions().get(get_enum_selection(0)).args
 
 
 func _get_argument_display_name(arg_name: StringName) -> String:
@@ -156,16 +157,20 @@ func _get_output_ports_list() -> Array[StringName]:
 
 
 func _get_output_port_display_name(_output_name: StringName) -> String:
-	return operation_definitions[get_enum_selection(0)].output
+	return _get_operation_definitions()[get_enum_selection(0)].output
 
 
 func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 	var operation: Operation = get_enum_selection(0) as Operation
 	var args: Array
-	for arg_name: StringName in operation_definitions[operation].args:
+	for arg_name: StringName in _get_operation_definitions()[operation].args:
 		args.append(_get_arg(arg_name, pouch))
 	return _get_new_value(operation, args)
 
 
 func _get_new_value(operation: Operation, args: Array) -> Variant:
-	return operation_definitions[operation].conversion.callv(args)
+	return _get_operation_definitions()[operation].conversion.callv(args)
+
+
+func _get_operation_definitions() -> Dictionary[Operation, Definition]:
+	return _number_operation_definitions

--- a/addons/gaea/runtime/graph_nodes/generic_classes/number_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/generic_classes/number_operation.gd
@@ -146,7 +146,8 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 	if not operation_definitions.is_empty():
 		return operation_definitions
 
-	operation_definitions = {
+	operation_definitions.clear()
+	operation_definitions.assign({
 		Operation.ADD:
 			Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
 		Operation.SUBTRACT:
@@ -197,5 +198,5 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 			),
 		Operation.WRAP:
 			Definition.new([&"a", &"min", &"max"], "wrap(a, min, max)", wrap),
-	}
+	})
 	return operation_definitions

--- a/addons/gaea/runtime/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
@@ -133,7 +133,8 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 	if not operation_definitions.is_empty():
 		return operation_definitions
 
-	operation_definitions = {
+	operation_definitions.clear()
+	operation_definitions.assign({
 		Operation.ADD:
 		Definition.new([&"a", &"b"], "A + B", func(a: Variant, b: Variant): return a + b),
 		Operation.SUBTRACT:
@@ -147,5 +148,5 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 			func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b
 		),
 		Operation.LERP: Definition.new([&"a", &"b", &"weight"], "lerp(a, b, weight)", lerpf)
-	}
+	})
 	return operation_definitions

--- a/addons/gaea/runtime/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/root/sampling/operations/multiple/samples_operation.gd
@@ -18,9 +18,17 @@ class Definition:
 
 
 ## All possible operations.
-var operation_definitions: Dictionary[Operation, Definition]:
-	get = _get_operation_definitions
-
+static var operation_definitions: Dictionary[Operation, Definition] = {
+	Operation.ADD: Definition.new([&"a", &"b"], "A + B", func(a: Variant, b: Variant): return a + b),
+	Operation.SUBTRACT: Definition.new([&"a", &"b"], "A - B", func(a: Variant, b: Variant): return a - b),
+	Operation.MULTIPLY: Definition.new([&"a", &"b"], "A * B", func(a: Variant, b: Variant): return a * b),
+	Operation.DIVIDE: Definition.new(
+		[&"a", &"b"],
+		"A / B",
+		func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b
+	),
+	Operation.LERP: Definition.new([&"a", &"b", &"weight"], "lerp(a, b, weight)", lerpf)
+}
 
 func _get_title() -> String:
 	return "SamplesOp"
@@ -127,26 +135,3 @@ func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValu
 			)
 		)
 	return result
-
-
-func _get_operation_definitions() -> Dictionary[Operation, Definition]:
-	if not operation_definitions.is_empty():
-		return operation_definitions
-
-	operation_definitions.clear()
-	operation_definitions.assign({
-		Operation.ADD:
-		Definition.new([&"a", &"b"], "A + B", func(a: Variant, b: Variant): return a + b),
-		Operation.SUBTRACT:
-		Definition.new([&"a", &"b"], "A - B", func(a: Variant, b: Variant): return a - b),
-		Operation.MULTIPLY:
-		Definition.new([&"a", &"b"], "A * B", func(a: Variant, b: Variant): return a * b),
-		Operation.DIVIDE:
-		Definition.new(
-			[&"a", &"b"],
-			"A / B",
-			func(a: Variant, b: Variant): return 0 if is_zero_approx(b) else a / b
-		),
-		Operation.LERP: Definition.new([&"a", &"b", &"weight"], "lerp(a, b, weight)", lerpf)
-	})
-	return operation_definitions

--- a/addons/gaea/runtime/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/root/sampling/operations/scalar/sample_operation.gd
@@ -3,6 +3,8 @@ class_name GaeaNodeSampleOp
 extends GaeaNodeNumOp
 ## Operations between all the cells of a sample grid and a [float] number.
 
+static var _custom_operation_definitions: Dictionary[Operation, Definition] = {}
+
 
 func _get_title() -> String:
 	return "SampleOp"
@@ -50,24 +52,26 @@ func _get_output_port_type(_output_name: StringName) -> GaeaValue.Type:
 
 
 func _get_operation_definitions() -> Dictionary[Operation, Definition]:
-	var definitions := super()
-	for definition: Definition in definitions.values():
+	if not _custom_operation_definitions.is_empty():
+		return _custom_operation_definitions
+	_custom_operation_definitions = super().duplicate_deep(Resource.DEEP_DUPLICATE_ALL)
+	for definition: Definition in _custom_operation_definitions.values():
 		# Kind of horrible code but it's fine
 		definition.output = definition.output.replace("a ", "A ")
 		definition.output = definition.output.replace(" a", " A")
 		definition.output = definition.output.replace("a,", "A,")
 		definition.output = definition.output.replace("(a)", "(A)")
 		definition.output = definition.output.replace("base", "A")
-	definitions[Operation.POWER].args[0] = &"a"
-	return definitions
+	_custom_operation_definitions[Operation.POWER].args[0] = &"a"
+	return _custom_operation_definitions
 
 
 func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> GaeaValue.Sample:
 	var operation: Operation = get_enum_selection(0) as Operation
-	var operation_definition: Definition = operation_definitions[operation]
+	var operation_definition: Definition = _get_operation_definitions()[operation]
 	var args: Array
 	var input_grid: GaeaValue.Sample = _get_arg(&"a", pouch)
-	for arg_name: StringName in operation_definitions[operation].args:
+	for arg_name: StringName in operation_definition.args:
 		if arg_name == &"a":
 			continue
 		args.append(_get_arg(arg_name, pouch))

--- a/addons/gaea/runtime/graph_nodes/root/scalar/operations/int_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/root/scalar/operations/int_operation.gd
@@ -3,6 +3,7 @@ class_name GaeaNodeIntOp
 extends GaeaNodeNumOp
 ## [int] operation.
 
+static var _custom_operation_definitions: Dictionary[Operation, Definition] = {}
 
 func _get_title() -> String:
 	return "IntOp"
@@ -30,11 +31,13 @@ func _get_description() -> String:
 
 
 func _get_operation_definitions() -> Dictionary[Operation, Definition]:
-	var definitions := super()
-	#definitions.erase(Operation.SNAPPED)
-	definitions.erase(Operation.CEIL)
-	definitions.erase(Operation.FLOOR)
-	definitions.erase(Operation.ROUND)
-	definitions.erase(Operation.SMOOTHSTEP)
-	definitions.erase(Operation.REMAP)
-	return definitions
+	if not _custom_operation_definitions.is_empty():
+		return _custom_operation_definitions
+
+	_custom_operation_definitions = super().duplicate_deep(Resource.DEEP_DUPLICATE_ALL)
+	_custom_operation_definitions.erase(Operation.CEIL)
+	_custom_operation_definitions.erase(Operation.FLOOR)
+	_custom_operation_definitions.erase(Operation.ROUND)
+	_custom_operation_definitions.erase(Operation.SMOOTHSTEP)
+	_custom_operation_definitions.erase(Operation.REMAP)
+	return _custom_operation_definitions

--- a/addons/gaea/runtime/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/root/vector/operations/vector_operation.gd
@@ -22,9 +22,16 @@ class Definition:
 		conversion = _conversion
 
 
-var operation_definitions: Dictionary[Operation, Definition]:
-	get = _get_operation_definitions
-
+static var operation_definitions: Dictionary[Operation, Definition] = {
+	Operation.ADD: Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
+	Operation.SUBTRACT: Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
+	Operation.MULTIPLY: Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
+	Operation.DIVIDE: Definition.new(
+		[&"a", &"b"],
+		"a / b",
+		func(a: Variant, b: Variant): return 0 if b.is_zero_approx() else a / b
+	),
+}
 
 func _get_title() -> String:
 	return "VectorOp"
@@ -130,25 +137,3 @@ func _get_data(_output_port: StringName, pouch: GaeaGenerationPouch) -> Variant:
 
 func _get_new_value(operation: Operation, args: Array) -> Variant:
 	return operation_definitions[operation].conversion.callv(args)
-
-
-func _get_operation_definitions() -> Dictionary[Operation, Definition]:
-	if not operation_definitions.is_empty():
-		return operation_definitions
-
-	operation_definitions.clear()
-	operation_definitions.assign({
-		Operation.ADD:
-		Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
-		Operation.SUBTRACT:
-		Definition.new([&"a", &"b"], "a - b", func(a: Variant, b: Variant): return a - b),
-		Operation.MULTIPLY:
-		Definition.new([&"a", &"b"], "a * b", func(a: Variant, b: Variant): return a * b),
-		Operation.DIVIDE:
-		Definition.new(
-			[&"a", &"b"],
-			"a / b",
-			func(a: Variant, b: Variant): return 0 if b.is_zero_approx() else a / b
-		),
-	})
-	return operation_definitions

--- a/addons/gaea/runtime/graph_nodes/root/vector/operations/vector_operation.gd
+++ b/addons/gaea/runtime/graph_nodes/root/vector/operations/vector_operation.gd
@@ -136,7 +136,8 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 	if not operation_definitions.is_empty():
 		return operation_definitions
 
-	operation_definitions = {
+	operation_definitions.clear()
+	operation_definitions.assign({
 		Operation.ADD:
 		Definition.new([&"a", &"b"], "a + b", func(a: Variant, b: Variant): return a + b),
 		Operation.SUBTRACT:
@@ -149,5 +150,5 @@ func _get_operation_definitions() -> Dictionary[Operation, Definition]:
 			"a / b",
 			func(a: Variant, b: Variant): return 0 if b.is_zero_approx() else a / b
 		),
-	}
+	})
 	return operation_definitions


### PR DESCRIPTION
For some reason, sometimes Godot thinks the type Dictionary[Operation, Definition] is not Dictionary[Operation, Definition]. I am not sure why, but for now we keep the typed dictionary instead of replacing it.

<img width="1244" height="365" alt="image" src="https://github.com/user-attachments/assets/59abe6f5-6f44-4153-8949-fb38d95196f1" />
