### PR TITLE
Fix copy pasting of nodes

### DIFF
--- a/addons/gaea/runtime/resources/graph.gd
+++ b/addons/gaea/runtime/resources/graph.gd
@@ -454,10 +454,10 @@ func paste_nodes(copy: GaeaNodesCopy, at_position: Vector2) -> Array[int]:
 		var copy_id: int = -1
 		match copy.get_node_type(id):
 			NodeType.NODE:
-				copy_id = add_node_with_data(copy.get_node_resource(id), copy.get_node_data(id))
+				copy_id = add_node_with_data(copy.instantiate_node_resource(id), copy.get_node_data(id).duplicate_deep())
 				set_node_salt(copy_id, randi())
 			NodeType.FRAME:
-				copy_id = add_frame_with_data(copy.get_node_data(id))
+				copy_id = add_frame_with_data(copy.get_node_data(id).duplicate_deep())
 				frames.append(copy_id)
 		set_node_position(copy_id, copy.get_node_position(id) + offset)
 		id_mapping.set(id, copy_id)

--- a/addons/gaea/runtime/resources/nodes_copy.gd
+++ b/addons/gaea/runtime/resources/nodes_copy.gd
@@ -1,3 +1,5 @@
+@tool
+
 class_name GaeaNodesCopy
 extends RefCounted
 ## An object that holds data to be pasted into a GaeaGraph.
@@ -63,6 +65,15 @@ func get_node_type(id: int) -> GaeaGraph.NodeType:
 
 func get_node_resource(id: int) -> GaeaNodeResource:
 	return _nodes.get(id, {}).get(&"resource")
+
+
+## Instantiate a fresh node resource from the node's script UID.
+func instantiate_node_resource(id: int) -> GaeaNodeResource:
+	var uid: String = get_node_data(id).get(&"uid")
+	if uid == null or not GaeaNodeResource.is_valid_node_resource(uid).is_empty():
+		push_error("Can't load resource script with UID '%s'" % uid)
+		return GaeaNodeInvalidScript.new()
+	return load(uid).new()
 
 
 func get_node_data(id: int) -> Dictionary:


### PR DESCRIPTION
When pasting the node, we were still using the same reference, so only the data from the last copy was used for all nodes, resulting in all nodes being stacked and probably some other wrong beavior like the same name for parameters.

From bug report on [Discord](https://discord.com/channels/1142834520584892447/1142849575657410621/1485018770958450708)