### PR TITLE
Fix documentation toolkit missing graph reference

### DIFF
--- a/addons/gaea/runtime/graph_nodes/special/output.gd
+++ b/addons/gaea/runtime/graph_nodes/special/output.gd
@@ -17,8 +17,9 @@ func _get_title() -> String:
 
 func _get_arguments_list() -> Array[StringName]:
 	var layers: Array[StringName] = []
-	for layer_idx in graph.layers.size():
-		layers.append(&"%d" % layer_idx)
+	if is_instance_valid(graph):
+		for layer_idx in graph.layers.size():
+			layers.append(&"%d" % layer_idx)
 	return layers
 
 

--- a/addons/gaea/runtime/graph_nodes/special/parameter.gd
+++ b/addons/gaea/runtime/graph_nodes/special/parameter.gd
@@ -76,9 +76,10 @@ func _get_available_name(from: String) -> String:
 	from = from.rstrip("1234567890")
 	var available_name: String = from
 	var suffix: int = 1
-	while graph.has_parameter(available_name):
-		suffix += 1
-		available_name = "%s%s" % [from, suffix]
+	if is_instance_valid(graph):
+		while graph.has_parameter(available_name):
+			suffix += 1
+			available_name = "%s%s" % [from, suffix]
 	return available_name
 
 

--- a/addons/gaea_documentation_toolkit/documentation_toolkit.gd
+++ b/addons/gaea_documentation_toolkit/documentation_toolkit.gd
@@ -135,7 +135,7 @@ func _get_node_documentation(resource: GaeaNodeResource) -> String:
 	node_path = node_path.get_base_dir()
 	node_path = node_path.trim_prefix(tree.NODES_FOLDER_PATH)
 	node_path = node_path.trim_prefix(GaeaProjectSettings.get_custom_nodes_path())
-	data.set("category", " > ".join(Array(node_path.split("/")).map(func(part: String): return part.capitalize())))
+	data.set("category", " > ".join(Array(node_path.split("/", false)).map(func(part: String): return part.capitalize())))
 
 	var extra_title = resource.get_extra_documentation(GaeaNodeResource.DocumentationSection.TITLE)
 	if not extra_title.is_empty():
@@ -145,7 +145,7 @@ func _get_node_documentation(resource: GaeaNodeResource) -> String:
 	data.set("description", resource.get_description())
 
 	var template: String = """---
-template: node.html
+template: graph_node.html
 type: {type}
 image: {image_path}
 category: {category}


### PR DESCRIPTION
This PR the missing graph reference when the nodes are used in the documentation toolkit
Also update the template path for the graph nodes